### PR TITLE
fix: disconnect rate-limited stream

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-12
+
+- Made legacy Twitter stream error `420` disconnect the listener while
+  preserving continuation for other errors and timeouts.
+- Added no-network listener decision tests.
+
 ## 2026-06-09
 
 - Added stable `make lint`, `make build`, and `make verify` aliases around the

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   falling back to a configured MongoDB URL when a fake client is falsy.
 - Required stream fields are normalized before storage: `text` and
   `screen_name` must be non-empty strings after trimming whitespace.
+- Legacy Twitter streaming status `420` disconnects the listener instead of
+  repeatedly reconnecting while rate limited; other errors and timeouts keep
+  the existing continuation behavior.
 - Local verification runs with Python bytecode writes disabled so no
   `__pycache__` output remains after the no-network gates.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,8 @@ Non-string raw stream payloads should be ignored like malformed JSON rather
 than terminating the worker.
 Explicit MongoDB client injection should be honored in no-network tests so fake
 clients cannot fall through to configured MongoDB URLs.
+Legacy stream rate-limit status `420` should disconnect instead of entering a
+reconnect loop that escalates upstream backoff.
 Python bytecode is local tooling output and should not remain after no-network
 verification gates.
 Pinned, read-only hosted Linux validation runs the fake-client baseline on two

--- a/VISION.md
+++ b/VISION.md
@@ -38,6 +38,7 @@ Priority:
 - Keep bounded track term preflight ahead of API and listener setup
 - Keep non-string raw stream payloads non-fatal
 - Keep explicit MongoDB client injection reliable for no-network tests
+- Keep legacy stream rate-limit errors from reconnecting indefinitely
 - Keep verification targets from leaving Python bytecode behind
 - Keep Python 3.10 and 3.12 hosted Linux validation credential-free and
   no-network

--- a/docs/plans/2026-06-12-stream-rate-limit-disconnect.md
+++ b/docs/plans/2026-06-12-stream-rate-limit-disconnect.md
@@ -1,6 +1,6 @@
 # Stream Rate Limit Disconnect
 
-status: planned
+status: completed
 
 ## Context
 
@@ -35,9 +35,11 @@ Official behavior reference:
 ## Verification
 
 - `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_sample_stream.py`
-- `make lint`
-- `make test`
-- `make build`
-- `make check`
-- A mutation restoring unconditional `True` from `on_error` is rejected.
-- `git diff --check`
+  passed with 15 tests on 2026-06-12.
+- `make lint` passed on 2026-06-12.
+- `make test` passed with 15 tests on 2026-06-12.
+- `make build` passed on 2026-06-12.
+- `make check` passed on 2026-06-12.
+- The focused rate-limit test rejected a mutation restoring `True` for status
+  `420` on 2026-06-12.
+- `git diff --check` passed on 2026-06-12.

--- a/docs/plans/2026-06-12-stream-rate-limit-disconnect.md
+++ b/docs/plans/2026-06-12-stream-rate-limit-disconnect.md
@@ -1,0 +1,43 @@
+# Stream Rate Limit Disconnect
+
+status: planned
+
+## Context
+
+`CustomStreamListener.on_error` currently returns `True` for every Twitter
+streaming status code. Tweepy's legacy `StreamListener` guidance specifically
+requires returning `False` for status `420` so the stream disconnects instead
+of repeatedly reconnecting while rate limited and escalating the backoff
+window.
+
+Official behavior reference:
+
+- https://docs.tweepy.org/en/v3.5.0/streaming_how_to.html#handling-errors
+
+## Objectives
+
+- Return `False` for legacy streaming rate-limit status `420`.
+- Preserve `True` for other status codes so Tweepy can apply its reconnect
+  behavior.
+- Preserve timeout continuation behavior.
+- Add no-network tests for rate-limit disconnect, ordinary error continuation,
+  and timeout continuation.
+- Extend the baseline and maintenance documentation for the explicit stream
+  error decision.
+
+## Scope Boundaries
+
+- Do not upgrade Tweepy or migrate the retired Twitter API integration.
+- Do not add custom sleep, retry, or backoff loops around Tweepy.
+- Do not log credentials, MongoDB URLs, payloads, or raw upstream errors.
+- Do not modify existing pull requests #2 or #3.
+
+## Verification
+
+- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_sample_stream.py`
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- A mutation restoring unconditional `True` from `on_error` is rejected.
+- `git diff --check`

--- a/sample_stream.py
+++ b/sample_stream.py
@@ -84,6 +84,8 @@ class CustomStreamListener(tweepy.StreamListener):
         return True
 
     def on_error(self, status_code):
+        if status_code == 420:
+            return False
         return True  # Don't kill the stream
 
     def on_timeout(self):

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -10,6 +10,7 @@ import xml.etree.ElementTree as ET
 ROOT = Path(__file__).resolve().parents[1]
 PLAN = "docs/plans/2026-06-08-oscars-stream-baseline.md"
 HOSTED_VALIDATION_PLAN = "docs/plans/2026-06-10-hosted-no-network-validation.md"
+RATE_LIMIT_DISCONNECT_PLAN = "docs/plans/2026-06-12-stream-rate-limit-disconnect.md"
 REQUIRED = [
     ".github/workflows/check.yml",
     ".gitignore",
@@ -33,6 +34,7 @@ REQUIRED = [
     "docs/plans/2026-06-10-explicit-mongo-client-injection.md",
     "docs/plans/2026-06-10-bounded-track-term-preflight.md",
     HOSTED_VALIDATION_PLAN,
+    RATE_LIMIT_DISCONNECT_PLAN,
     "requirements.txt",
     "sample_stream.py",
     "scripts/check-baseline.py",
@@ -87,6 +89,8 @@ def main():
         "except TypeError",
         "except (TypeError, ValueError)",
         "mongo_client is not None",
+        "if status_code == 420",
+        "return False",
     ]:
         if phrase not in stream:
             failures.append(f"sample_stream.py must include {phrase}")
@@ -112,6 +116,9 @@ def main():
         "UserDict",
         "FalsyMongoClient",
         "test_listener_uses_explicit_falsy_mongo_client",
+        "test_listener_disconnects_on_stream_rate_limit",
+        "test_listener_continues_on_other_stream_errors",
+        "test_listener_continues_after_timeout",
         "test_start_stream_validates_track_terms_before_client_setup",
         "test_start_stream_rejects_more_than_one_hundred_track_terms",
     ]:
@@ -176,6 +183,7 @@ def main():
         "Python bytecode",
         "explicit MongoDB client injection",
         "bounded track term preflight",
+        "stream rate-limit",
         "hosted Linux",
     ]:
         if phrase.lower() not in docs.lower():
@@ -221,6 +229,13 @@ def main():
     hosted_validation_plan = read(HOSTED_VALIDATION_PLAN)
     if "status: completed" not in hosted_validation_plan or "make check" not in hosted_validation_plan:
         failures.append("hosted no-network validation plan must record completed status and verification")
+    rate_limit_disconnect_plan = read(RATE_LIMIT_DISCONNECT_PLAN)
+    if (
+        "status: completed" not in rate_limit_disconnect_plan
+        or "status `420`" not in rate_limit_disconnect_plan
+        or "make check" not in rate_limit_disconnect_plan
+    ):
+        failures.append("stream rate-limit disconnect plan must record completed status and verification")
 
     try:
         ET.parse(ROOT / "docs/readme-overview.svg")

--- a/test_sample_stream.py
+++ b/test_sample_stream.py
@@ -195,6 +195,27 @@ class SampleStreamTest(unittest.TestCase):
 
         self.assertIs(client.TweetDB, listener.db)
 
+    def test_listener_disconnects_on_stream_rate_limit(self):
+        sample_stream = load_sample_stream()
+        client = FakeMongoClient("mongodb://example.invalid/db")
+        listener = sample_stream.CustomStreamListener(api=object(), mongo_client=client)
+
+        self.assertFalse(listener.on_error(420))
+
+    def test_listener_continues_on_other_stream_errors(self):
+        sample_stream = load_sample_stream()
+        client = FakeMongoClient("mongodb://example.invalid/db")
+        listener = sample_stream.CustomStreamListener(api=object(), mongo_client=client)
+
+        self.assertTrue(listener.on_error(500))
+
+    def test_listener_continues_after_timeout(self):
+        sample_stream = load_sample_stream()
+        client = FakeMongoClient("mongodb://example.invalid/db")
+        listener = sample_stream.CustomStreamListener(api=object(), mongo_client=client)
+
+        self.assertTrue(listener.on_timeout())
+
     def test_listener_ignores_malformed_or_incomplete_payloads(self):
         sample_stream = load_sample_stream()
         client = FakeMongoClient("mongodb://example.invalid/db")


### PR DESCRIPTION
## Summary

Disconnect the legacy Tweepy stream on Twitter status `420` instead of repeatedly reconnecting while rate limited.

## Baseline

`CustomStreamListener.on_error` returned `True` for every status code. Official legacy Tweepy `StreamListener` guidance calls for returning `False` on `420` because repeated reconnect attempts increase the rate-limit backoff window.

## Improvements

- return `False` for streaming status `420`
- preserve `True` for other stream errors
- preserve timeout continuation behavior
- add no-network tests for all three decisions
- enforce the decision and completed plan through the existing static baseline

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_sample_stream.py` (15 passed)
- `make lint`
- `make test` (15 passed)
- `make build`
- `make check`
- unconditional reconnect mutation rejected by the focused 420 test
- `git diff --check`

## Risk

The worker uses retired Tweepy 2.2 and a retired Twitter streaming API. This change is deliberately limited to the documented legacy `420` callback decision and does not add logging, sleeps, retries, dependency changes, or network calls.

## Follow-Ups

Any migration to a supported API should replace this worker in a separate compatibility change with current authentication, streaming, and persistence tests.
