### PR TITLE
security: modernize Oscars stream dependencies

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,22 @@ jobs:
       PYTHONDONTWRITEBYTECODE: "1"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ matrix.python-version }}
+      - run: python -m pip install --disable-pip-version-check -r requirements.lock
       - run: make check
+  dependency-audit:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --disable-pip-version-check pip-audit==2.10.0
+      - run: pip-audit -r requirements.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Scope
+
+These instructions apply to the entire repository.
+
+## Runtime
+
+- Use Python 3.9 or newer.
+- Install the exact resolved graph from `requirements.lock` before
+  running the worker or the complete hosted-equivalent gate.
+- Keep Twitter/X and MongoDB credentials in environment variables only.
+
+## Development Commands
+
+- Full offline baseline: `make check`
+- Tests: `make test`
+- Static contract: `make lint`
+- Build alias: `make build`
+- Dependency audit: `pip-audit -r requirements.lock`
+
+## Engineering Contracts
+
+- Keep tests no-network through fake Tweepy and MongoDB clients.
+- Validate track terms and the final rule byte length before client setup.
+- Manage only API v2 rules tagged `oscars-sample-stream`; never delete
+  unrelated project rules.
+- Require author expansion before storing a normalized username.
+- Use `insert_one` for MongoDB writes and preserve explicit falsy-client
+  injection.
+- Disconnect on stream rate limits 420 and 429.
+- Do not commit bearer tokens, MongoDB URLs, captured posts, or local env files.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## 2026-06-12
 
+- Replaced vulnerable Tweepy 2.2 and PyMongo 2.6.3 pins with exact maintained
+  Tweepy 4.16.0 and PyMongo 4.17.0 releases.
+- Migrated the retired Twitter API v1.1 listener to a bearer-token API v2
+  `StreamingClient` with bounded, tagged rule replacement and author expansion.
+- Moved MongoDB writes to `insert_one` and added a resolved dependency audit.
 - Made legacy Twitter stream error `420` disconnect the listener while
   preserving continuation for other errors and timeouts.
 - Added no-network listener decision tests.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-12
+
+- Made legacy Twitter stream error `420` disconnect the listener while
+  preserving continuation for other errors and timeouts.
+- Added no-network listener decision tests.
+
 ## 2026-06-09
 
 - Added stable `make lint`, `make build`, and `make verify` aliases around the

--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@
 
 `garethpaul/oscars-sample-stream` is a Python project. Sample Streaming API for #oscars
 
-This README is based on the checked-in source, manifests, scripts, and repository metadata on the `master` branch. The project language mix found during review was: Python (2).
+The maintained worker targets Python 3.9 or newer and uses the Twitter/X API
+v2 filtered stream through Tweepy 4.16.0 `StreamingClient` plus PyMongo 4.17.0.
 
 ## Repository Contents
 
 - `CHANGES.md` - baseline change log
 - `Makefile` - local no-network verification entry point
 - `README.md` - project overview and local usage notes
-- `requirements.txt` - Python dependency or packaging metadata
+- `requirements.txt` - exact direct runtime dependency pins
+- `requirements.lock` - exact resolved production dependency graph
 - `Procfile`
 - `SECURITY.md` - security reporting and disclosure guidance
 - `config.py` - environment-variable configuration loader
@@ -36,27 +38,30 @@ Additional scan context:
 ### Prerequisites
 
 - Git
-- Python matching the era of the project
+- Python 3.9 or newer
 
 ### Setup
 
 ```bash
 git clone https://github.com/garethpaul/oscars-sample-stream.git
 cd oscars-sample-stream
-python -m pip install -r requirements.txt
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install -r requirements.lock
 ```
 
-The setup commands above are derived from repository files. Legacy mobile, Python, or JavaScript samples may require older SDKs or package versions than a modern workstation uses by default.
+The exact dependency graph should also pass `pip-audit -r requirements.lock`.
 
 ## Running or Using the Project
 
-- Configure Twitter credentials with `consumer_key`, `consumer_secret`,
-  `access_key`, and `access_secret` environment variables, or uppercase
-  equivalents.
+- Configure a Twitter/X API v2 bearer token with `bearer_token` or
+  `BEARER_TOKEN`.
 - Configure MongoDB with `MONGOHQ_URL` or `MONGO_URL`.
 - Blank environment values are ignored so fallback variable names can be used.
 - Run `python sample_stream.py` or the Heroku `worker` process from `Procfile`.
-- The default stream filter is `#oscars`.
+- The default stream filter is `#oscars`. The worker replaces only persistent
+  API v2 rules tagged `oscars-sample-stream`; unrelated project rules are not
+  deleted.
 - Custom stream filters must contain at least one non-empty string after
   trimming; blank custom stream filters are rejected instead of silently using
   the default.
@@ -70,11 +75,12 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   keeps running on unexpected callbacks.
 - Explicit MongoDB client injection is honored for no-network tests instead of
   falling back to a configured MongoDB URL when a fake client is falsy.
-- Required stream fields are normalized before storage: `text` and
-  `screen_name` must be non-empty strings after trimming whitespace.
-- Legacy Twitter streaming status `420` disconnects the listener instead of
-  repeatedly reconnecting while rate limited; other errors and timeouts keep
-  the existing continuation behavior.
+- API v2 author expansion is required before storage: tweet `text` and the
+  matching expanded `username` must be non-empty strings after trimming.
+- Twitter/X streaming statuses `420` and `429` disconnect the client instead
+  of repeatedly reconnecting while rate limited.
+- MongoDB writes use PyMongo `insert_one`; tests preserve explicit falsy client
+  injection without contacting a database.
 - Local verification runs with Python bytecode writes disabled so no
   `__pycache__` output remains after the no-network gates.
 
@@ -86,14 +92,15 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - `make verify`
 - `python3 -m unittest discover -v`
 - `python3 scripts/check-baseline.py`
-- Pinned hosted Linux validation runs the no-network `make check` gate on
-  Python 3.10 and 3.12 without installing Tweepy, PyMongo, or using credentials.
+- Pinned hosted Linux validation installs the exact requirements and runs the
+  no-network `make check` gate on Python 3.10 and 3.12 without credentials.
+- A separate Python 3.12 job audits the resolved production dependency graph.
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.
 
 ## Configuration and Secrets
 
-- Detected references to Twitter. Keep API keys, OAuth credentials, tokens, and account-specific values in local configuration only.
+- Keep bearer tokens and account-specific values in local configuration only.
 - Never commit Twitter credentials, MongoDB URLs, captured posts, or local `.env`
   files.
 
@@ -118,6 +125,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Non-string raw stream payloads should not terminate the streaming worker.
 - Explicit MongoDB client injection should stay reliable for fake clients used
   in no-network tests.
+- Tagged API v2 rule replacement must never delete another worker's rules.
+- Stream payloads without a matching expanded author must not be stored.
 
 ## Maintenance Notes
 
@@ -128,6 +137,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   the current worker baseline.
 - See `docs/plans/2026-06-10-hosted-no-network-validation.md` for the hosted
   Linux no-network test contract.
+- See `docs/plans/2026-06-12-modern-stream-dependencies.md` for the API v2,
+  bearer-token, tagged-rule, PyMongo, and dependency-audit migration.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   falling back to a configured MongoDB URL when a fake client is falsy.
 - Required stream fields are normalized before storage: `text` and
   `screen_name` must be non-empty strings after trimming whitespace.
+- Legacy Twitter streaming status `420` disconnects the listener instead of
+  repeatedly reconnecting while rate limited; other errors and timeouts keep
+  the existing continuation behavior.
 - Local verification runs with Python bytecode writes disabled so no
   `__pycache__` output remains after the no-network gates.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,8 +28,8 @@ Helpful reports include:
 - Review found authentication, token, or session-related code paths; changes in those areas should receive security-focused review before merge.
 - Review found file, document, data, or media parsing flows; changes in those areas should receive security-focused review before merge.
 - Dependency manifests detected: requirements.txt. Dependency updates should preserve lockfiles when present and avoid introducing packages without a clear maintenance reason.
-- Twitter credentials and MongoDB URLs must come from environment variables
-  such as `consumer_key`, `access_key`, and `MONGOHQ_URL`; do not commit local
+- Twitter/X bearer tokens and MongoDB URLs must come from environment variables
+  such as `BEARER_TOKEN` and `MONGOHQ_URL`; do not commit local
   `.env` files or captured stream payloads.
 
 ## Service and API Notes
@@ -41,8 +41,9 @@ and error handling around malformed payloads. Run `make check` before changing
 credential handling or stream startup.
 Use `make lint`, `make build`, and `make verify` as the stable local aliases
 for static verification and the full no-network gate.
-Required stream fields should be strings with meaningful content after
-whitespace trimming before they are written to MongoDB.
+Required API v2 tweet text and expanded usernames should be strings with
+meaningful content after whitespace trimming before they are written to
+MongoDB with `insert_one`.
 Blank environment values should be ignored rather than treated as configured
 credentials or MongoDB URLs.
 Custom stream filters should include at least one non-empty string after
@@ -61,8 +62,14 @@ Legacy stream rate-limit status `420` should disconnect instead of entering a
 reconnect loop that escalates upstream backoff.
 Python bytecode is local tooling output and should not remain after no-network
 verification gates.
-Pinned, read-only hosted Linux validation runs the fake-client baseline on two
-Python versions without credentials, live Twitter calls, or MongoDB access.
+Persistent API v2 rules are project-wide state. The worker may replace only
+rules tagged `oscars-sample-stream`; broad deletion could disrupt unrelated
+stream consumers. Rule expressions are bounded to 512 UTF-8 bytes before
+client setup.
+Pinned, read-only hosted Linux validation installs Tweepy 4.16.0 and PyMongo
+4.17.0, then runs the fake-client baseline on two Python versions without
+credentials, live Twitter calls, or MongoDB access. A separate pinned
+dependency audit checks the exact resolved `requirements.lock` graph.
 
 ## Dependency and Supply Chain Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,8 @@ Non-string raw stream payloads should be ignored like malformed JSON rather
 than terminating the worker.
 Explicit MongoDB client injection should be honored in no-network tests so fake
 clients cannot fall through to configured MongoDB URLs.
+Legacy stream rate-limit status `420` should disconnect instead of entering a
+reconnect loop that escalates upstream backoff.
 Python bytecode is local tooling output and should not remain after no-network
 verification gates.
 Pinned, read-only hosted Linux validation runs the fake-client baseline on two

--- a/VISION.md
+++ b/VISION.md
@@ -10,14 +10,14 @@ The repository is useful as a compact example of wiring environment-based
 credentials, a streaming API client, and a hosted MongoDB add-on into a simple
 Python worker.
 
-The goal is to preserve the learning value while making the legacy API,
-dependency, and deployment assumptions obvious.
+The goal is to preserve the learning value on maintained Python, Twitter/X API
+v2, and MongoDB client interfaces while keeping deployment assumptions obvious.
 
 Current baseline: `make check` runs no-network tests with fake Tweepy and
-MongoDB clients and verifies the `#oscars` stream filter, environment-variable
-configuration, and static docs. `make lint`, `make build`, and `make verify`
-are stable aliases for static verification, build-through-static-check, and
-full verification.
+MongoDB clients and verifies the `#oscars` API v2 tagged rule,
+environment-variable configuration, author expansion, rate-limit disconnect,
+and static docs. `make lint`, `make build`, and `make verify` are stable aliases
+for static verification, build-through-static-check, and full verification.
 
 The current focus is:
 
@@ -26,7 +26,7 @@ Priority:
 - Preserve the Heroku worker shape and configuration flow
 - Keep credentials outside source files
 - Document the expected stream filter and MongoDB collection behavior
-- Treat the current Python and API dependencies as legacy
+- Keep Tweepy 4.16.0 and PyMongo 4.17.0 exact and audited
 - Keep no-network tests available for stream startup and payload handling
 - Treat malformed, non-object, and incomplete stream payloads as ignorable
   worker input
@@ -38,7 +38,9 @@ Priority:
 - Keep bounded track term preflight ahead of API and listener setup
 - Keep non-string raw stream payloads non-fatal
 - Keep explicit MongoDB client injection reliable for no-network tests
-- Keep legacy stream rate-limit errors from reconnecting indefinitely
+- Keep API v2 stream rate-limit errors from reconnecting indefinitely
+- Keep rule replacement scoped to the `oscars-sample-stream` tag
+- Require expanded author identity before MongoDB storage through `insert_one`
 - Keep verification targets from leaving Python bytecode behind
 - Keep Python 3.10 and 3.12 hosted Linux validation credential-free and
   no-network
@@ -50,7 +52,8 @@ Next priorities:
 - Move configuration examples into environment-variable documentation
 - Document retention and cleanup expectations for stored stream fields
 - Keep fake-client injection covered before changing MongoDB setup
-- Update dependencies only after documenting API compatibility changes
+- Exercise a credentialed API v2 and MongoDB smoke path in an isolated test
+  project before production use
 
 Contribution rules:
 
@@ -76,6 +79,7 @@ real captured payloads in the repository.
 - Broad data collection defaults
 - Silent storage of full payloads without documentation
 - Dependency upgrades that hide streaming API behavior changes
+- Broad deletion of persistent API v2 stream rules
 
 This list is a roadmap guardrail, not a permanent rule.
 Strong user demand and strong technical rationale can change it.

--- a/VISION.md
+++ b/VISION.md
@@ -38,6 +38,7 @@ Priority:
 - Keep bounded track term preflight ahead of API and listener setup
 - Keep non-string raw stream payloads non-fatal
 - Keep explicit MongoDB client injection reliable for no-network tests
+- Keep legacy stream rate-limit errors from reconnecting indefinitely
 - Keep verification targets from leaving Python bytecode behind
 - Keep Python 3.10 and 3.12 hosted Linux validation credential-free and
   no-network

--- a/config.py
+++ b/config.py
@@ -11,8 +11,9 @@ def required_env(*names):
     raise RuntimeError("Missing required environment variable: " + " or ".join(names))
 
 
-consumer_key = required_env("consumer_key", "CONSUMER_KEY")
-consumer_secret = required_env("consumer_secret", "CONSUMER_SECRET")
-access_key = required_env("access_key", "ACCESS_KEY")
-access_secret = required_env("access_secret", "ACCESS_SECRET")
-mongo_url = required_env("MONGOHQ_URL", "MONGO_URL")
+def bearer_token():
+    return required_env("bearer_token", "BEARER_TOKEN")
+
+
+def mongo_url():
+    return required_env("MONGOHQ_URL", "MONGO_URL")

--- a/docs/plans/2026-06-12-modern-stream-dependencies.md
+++ b/docs/plans/2026-06-12-modern-stream-dependencies.md
@@ -97,3 +97,6 @@ injection, and rate-limit disconnect behavior.
   downgrades, retired APIs, credential bypass, broad rule deletion, missing
   author expansion, lock drift, audit removal, incomplete evidence, and unsafe
   delete-before-add rule replacement.
+- Canonical push run `27431091719` and pull-request run `27431172948` passed
+  Python 3.10, Python 3.12, and the dependency-audit job with zero annotations
+  at implementation head `a987924593313554ed3d55c0bd8cfe388e7c3a93`.

--- a/docs/plans/2026-06-12-modern-stream-dependencies.md
+++ b/docs/plans/2026-06-12-modern-stream-dependencies.md
@@ -72,7 +72,8 @@ injection, and rate-limit disconnect behavior.
 - Pinned Tweepy 4.16.0 and PyMongo 4.17.0, locked the ten-package production
   graph, and replaced the removed listener and collection insertion interfaces.
 - Added bearer-token API v2 streaming, bounded literal rule generation, and
-  replacement limited to rules tagged `oscars-sample-stream`.
+  replacement limited to rules tagged `oscars-sample-stream`; prior tagged
+  rules are deleted only after the API confirms the replacement was created.
 - Required expanded author identity before normalized text and username are
   written through `insert_one`.
 - Preserved validation-before-setup, explicit falsy Mongo client injection,
@@ -87,9 +88,10 @@ injection, and rate-limit disconnect behavior.
   Python `>=3.9` metadata.
 - `pip-audit -r requirements.lock` reported no known vulnerabilities for the
   resolved production graph.
-- `python3 -m unittest -v test_sample_stream.py` passed 11 no-network tests for
+- `python3 -m unittest -v test_sample_stream.py` passed 12 no-network tests for
   tagged rules, literal and byte-bounded filters, author expansion, malformed
-  payloads, `insert_one`, explicit falsy clients, and 420/429 disconnects.
+  payloads, API-level rule rejection, `insert_one`, explicit falsy clients,
+  and 420/429 disconnects.
 - `make lint`, `make test`, `make build`, `make check`, Python compilation,
   workflow parsing, and `git diff --check` passed in the isolated Python 3.12
   environment.

--- a/docs/plans/2026-06-12-modern-stream-dependencies.md
+++ b/docs/plans/2026-06-12-modern-stream-dependencies.md
@@ -1,6 +1,6 @@
 # Modern Stream Dependencies
 
-status: planned
+status: completed
 
 ## Context
 
@@ -25,7 +25,8 @@ injection, and rate-limit disconnect behavior.
 
 ## Requirements
 
-- R1. Pin Tweepy 4.16.0 and PyMongo 4.17.0 exactly; both releases must install
+- R1. Pin Tweepy 4.16.0 and PyMongo 4.17.0 exactly, lock the resolved
+  production graph; both releases must install
   on the hosted Python 3.10 and 3.12 matrix and report zero known
   vulnerabilities through a pinned dependency-audit job.
 - R2. Replace OAuth 1.0a stream construction with a required bearer-token
@@ -65,3 +66,34 @@ injection, and rate-limit disconnect behavior.
   deletion, missing author expansion, legacy insert, and audit removal
 - `git diff --check`
 - successful exact-head push, pull-request, dependency-audit, and CodeQL runs
+
+## Work Completed
+
+- Pinned Tweepy 4.16.0 and PyMongo 4.17.0, locked the ten-package production
+  graph, and replaced the removed listener and collection insertion interfaces.
+- Added bearer-token API v2 streaming, bounded literal rule generation, and
+  replacement limited to rules tagged `oscars-sample-stream`.
+- Required expanded author identity before normalized text and username are
+  written through `insert_one`.
+- Preserved validation-before-setup, explicit falsy Mongo client injection,
+  lazy credential resolution, and rate-limit disconnects for statuses 420 and
+  429.
+- Added exact dependency installation and a pinned resolved audit to hosted
+  validation, plus repository guidance for the new boundary.
+
+## Verification Completed
+
+- The isolated exact install reported Tweepy 4.16.0 and PyMongo 4.17.0 with
+  Python `>=3.9` metadata.
+- `pip-audit -r requirements.lock` reported no known vulnerabilities for the
+  resolved production graph.
+- `python3 -m unittest -v test_sample_stream.py` passed 11 no-network tests for
+  tagged rules, literal and byte-bounded filters, author expansion, malformed
+  payloads, `insert_one`, explicit falsy clients, and 420/429 disconnects.
+- `make lint`, `make test`, `make build`, `make check`, Python compilation,
+  workflow parsing, and `git diff --check` passed in the isolated Python 3.12
+  environment.
+- Eleven isolated hostile mutations were rejected, covering dependency
+  downgrades, retired APIs, credential bypass, broad rule deletion, missing
+  author expansion, lock drift, audit removal, incomplete evidence, and unsafe
+  delete-before-add rule replacement.

--- a/docs/plans/2026-06-12-modern-stream-dependencies.md
+++ b/docs/plans/2026-06-12-modern-stream-dependencies.md
@@ -1,0 +1,67 @@
+# Modern Stream Dependencies
+
+status: planned
+
+## Context
+
+The worker still pins Tweepy 2.2 and PyMongo 2.6.3. GitHub reports one medium
+advisory for each package. Current secure releases cross real compatibility
+boundaries: Tweepy 4.16.0 requires Python 3.9 or newer and removed the retired
+Twitter API v1.1 `Stream` interface, while PyMongo 4.17.0 removed the legacy
+collection `insert` method used by this sample.
+
+Tweepy now exposes realtime filtering through Twitter API v2
+`StreamingClient`. That interface uses a bearer token, persistent server-side
+rules, author expansion data, and `on_request_error` instead of the legacy
+OAuth 1.0a listener callbacks. A manifest-only update would leave the worker
+unstartable and would not meet the repository's no-network verification bar.
+
+## Priority
+
+Remove both known direct-dependency advisories while migrating the small
+first-party integration surface to released, documented APIs. Preserve the
+existing bounded filter preflight, fail-closed payload handling, Mongo client
+injection, and rate-limit disconnect behavior.
+
+## Requirements
+
+- R1. Pin Tweepy 4.16.0 and PyMongo 4.17.0 exactly; both releases must install
+  on the hosted Python 3.10 and 3.12 matrix and report zero known
+  vulnerabilities through a pinned dependency-audit job.
+- R2. Replace OAuth 1.0a stream construction with a required bearer-token
+  configuration and a Tweepy `StreamingClient` subclass.
+- R3. Convert cleaned track terms into one bounded API v2 rule expression,
+  tag it for this worker, and replace only existing rules with that exact tag.
+  Unrelated project rules must remain untouched.
+- R4. Request author expansion and username fields when starting the stream,
+  then store only validated tweet text and the matching expanded username.
+- R5. Ignore malformed, non-object, incomplete, or unmatched-author payloads
+  without writing to MongoDB or exposing payload contents in errors.
+- R6. Use PyMongo `insert_one` and preserve explicit falsy Mongo client
+  injection for no-network tests.
+- R7. Disconnect the API v2 stream on rate-limit status 420 or 429 while
+  retaining bounded retry behavior for other request and connection errors.
+- R8. Preserve validation before credential, Mongo, or stream setup; tests
+  must inject fake Tweepy and PyMongo modules and make no external requests.
+- R9. Update README, security, vision, changes, contributor guidance, the
+  static baseline, and this plan with the actual migration and verification
+  evidence.
+
+## Scope Boundaries
+
+- Do not contact Twitter/X or MongoDB from local or hosted verification.
+- Do not delete or replace API v2 rules that are not tagged for this worker.
+- Do not restore the retired Twitter API v1.1 stream or legacy Mongo insert
+  API for compatibility.
+- Do not merge or close the repository's existing pull requests.
+
+## Verification
+
+- clean isolated install of both exact requirements
+- production dependency audit reports zero known vulnerabilities
+- focused API v2 rule, payload, rate-limit, and Mongo insertion tests
+- `make lint`, `make test`, `make build`, and `make check`
+- hostile mutations for legacy pins/APIs, bearer-token bypass, broad rule
+  deletion, missing author expansion, legacy insert, and audit removal
+- `git diff --check`
+- successful exact-head push, pull-request, dependency-audit, and CodeQL runs

--- a/docs/plans/2026-06-12-stream-rate-limit-disconnect.md
+++ b/docs/plans/2026-06-12-stream-rate-limit-disconnect.md
@@ -32,7 +32,14 @@ Official behavior reference:
 - Do not log credentials, MongoDB URLs, payloads, or raw upstream errors.
 - Do not modify existing pull requests #2 or #3.
 
-## Verification
+## Work Completed
+
+- Returned `False` from `on_error(420)` to stop the legacy stream.
+- Preserved `True` for ordinary stream errors and timeout continuation.
+- Added no-network listener tests for all three decisions.
+- Preserved the retired integration boundary without custom backoff logic.
+
+## Verification Completed
 
 - `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_sample_stream.py`
   passed with 15 tests on 2026-06-12.
@@ -43,3 +50,12 @@ Official behavior reference:
 - The focused rate-limit test rejected a mutation restoring `True` for status
   `420` on 2026-06-12.
 - `git diff --check` passed on 2026-06-12.
+- `python3 -m py_compile scripts/check-baseline.py` passed.
+- Canonical push run `27398483979` and pull-request run `27398488269`
+  completed successfully at exact head
+  `49fa4143965b1f5081d9288f73756bcb7096075d` across Python `3.10`
+  and Python `3.12`.
+- `test_listener_disconnects_on_stream_rate_limit` preserves
+  `self.assertFalse(listener.on_error(420))`.
+- `test_listener_continues_on_other_stream_errors` and
+  `test_listener_continues_after_timeout` preserve continuation behavior.

--- a/docs/plans/2026-06-12-stream-rate-limit-disconnect.md
+++ b/docs/plans/2026-06-12-stream-rate-limit-disconnect.md
@@ -1,6 +1,6 @@
 # Stream Rate Limit Disconnect
 
-status: planned
+status: completed
 
 ## Context
 
@@ -35,9 +35,11 @@ Official behavior reference:
 ## Verification
 
 - `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_sample_stream.py`
-- `make lint`
-- `make test`
-- `make build`
-- `make check`
-- A mutation restoring unconditional `True` from `on_error` is rejected.
-- `git diff --check`
+  passed with 15 tests on 2026-06-12.
+- `make lint` passed on 2026-06-12.
+- `make test` passed with 15 tests on 2026-06-12.
+- `make build` passed on 2026-06-12.
+- `make check` passed on 2026-06-12.
+- The focused rate-limit test rejected a mutation restoring `True` for status
+  `420` on 2026-06-12.
+- `git diff --check` passed on 2026-06-12.

--- a/docs/plans/2026-06-12-stream-rate-limit-disconnect.md
+++ b/docs/plans/2026-06-12-stream-rate-limit-disconnect.md
@@ -1,0 +1,43 @@
+# Stream Rate Limit Disconnect
+
+status: planned
+
+## Context
+
+`CustomStreamListener.on_error` currently returns `True` for every Twitter
+streaming status code. Tweepy's legacy `StreamListener` guidance specifically
+requires returning `False` for status `420` so the stream disconnects instead
+of repeatedly reconnecting while rate limited and escalating the backoff
+window.
+
+Official behavior reference:
+
+- https://docs.tweepy.org/en/v3.5.0/streaming_how_to.html#handling-errors
+
+## Objectives
+
+- Return `False` for legacy streaming rate-limit status `420`.
+- Preserve `True` for other status codes so Tweepy can apply its reconnect
+  behavior.
+- Preserve timeout continuation behavior.
+- Add no-network tests for rate-limit disconnect, ordinary error continuation,
+  and timeout continuation.
+- Extend the baseline and maintenance documentation for the explicit stream
+  error decision.
+
+## Scope Boundaries
+
+- Do not upgrade Tweepy or migrate the retired Twitter API integration.
+- Do not add custom sleep, retry, or backoff loops around Tweepy.
+- Do not log credentials, MongoDB URLs, payloads, or raw upstream errors.
+- Do not modify existing pull requests #2 or #3.
+
+## Verification
+
+- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_sample_stream.py`
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- A mutation restoring unconditional `True` from `on_error` is rejected.
+- `git diff --check`

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,0 +1,10 @@
+certifi==2026.5.20
+charset-normalizer==3.4.7
+dnspython==2.8.0
+idna==3.18
+oauthlib==3.3.1
+pymongo==4.17.0
+requests==2.34.2
+requests-oauthlib==2.0.0
+tweepy==4.16.0
+urllib3==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pymongo==2.6.3
-tweepy==2.2
+pymongo==4.17.0
+tweepy==4.16.0

--- a/sample_stream.py
+++ b/sample_stream.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import re
 from collections.abc import Mapping
 
 import pymongo
@@ -10,6 +11,9 @@ import config
 
 TRACK_TERMS = ["#oscars"]
 MAX_TRACK_TERMS = 100
+MAX_RULE_LENGTH = 512
+RULE_TAG = "oscars-sample-stream"
+HASHTAG = re.compile(r"^#[A-Za-z0-9_]+$")
 
 
 def clean_required_text(value):
@@ -43,65 +47,95 @@ def clean_track_terms(track_terms):
     return cleaned
 
 
-def create_api():
-    auth = tweepy.OAuthHandler(config.consumer_key, config.consumer_secret)
-    auth.set_access_token(config.access_key, config.access_secret)
-    return tweepy.API(auth)
+def stream_rule_value(track_terms):
+    terms = []
+    for term in track_terms:
+        if HASHTAG.fullmatch(term):
+            terms.append(term)
+        else:
+            escaped = term.replace("\\", "\\\\").replace('"', '\\"')
+            terms.append('"{}"'.format(escaped))
+    value = " OR ".join(terms)
+    if len(value.encode("utf-8")) > MAX_RULE_LENGTH:
+        raise ValueError("track_terms produce a stream rule larger than 512 bytes")
+    return value
 
 
-class CustomStreamListener(tweepy.StreamListener):
-    def __init__(self, api, mongo_client=None):
-        self.api = api
-        super(CustomStreamListener, self).__init__()
+def tagged_rule_ids(rules):
+    return [rule.id for rule in rules or [] if rule.tag == RULE_TAG]
+
+
+def sync_stream_rule(stream, rule_value):
+    current = stream.get_rules().data or []
+    existing_ids = tagged_rule_ids(current)
+    stream.add_rules(tweepy.StreamRule(value=rule_value, tag=RULE_TAG))
+    if existing_ids:
+        stream.delete_rules(existing_ids)
+
+
+def expanded_username(payload, author_id):
+    includes = payload.get("includes") or {}
+    if not isinstance(includes, dict):
+        return None
+    users = includes.get("users") or []
+    if not isinstance(users, list):
+        return None
+    for user in users:
+        if not isinstance(user, dict) or user.get("id") != author_id:
+            continue
+        return clean_required_text(user.get("username"))
+    return None
+
+
+class OscarsStream(tweepy.StreamingClient):
+    def __init__(self, bearer_token, mongo_client=None):
+        super().__init__(bearer_token, wait_on_rate_limit=False, max_retries=3)
         client = (
             mongo_client
             if mongo_client is not None
-            else pymongo.MongoClient(config.mongo_url)
+            else pymongo.MongoClient(config.mongo_url())
         )
         self.db = client.TweetDB
 
-    def on_data(self, tweet):
+    def on_data(self, raw_data):
         try:
-            data = json.loads(tweet)
+            payload = json.loads(raw_data)
         except (TypeError, ValueError):
-            return True
-        if not isinstance(data, dict):
-            return True
+            return
+        if not isinstance(payload, dict):
+            return
 
-        user = data.get("user") or {}
-        if not isinstance(user, dict):
-            return True
-        text = clean_required_text(data.get("text"))
-        screen_name = clean_required_text(user.get("screen_name"))
-        if not text or not screen_name:
-            return True
+        tweet = payload.get("data") or {}
+        if not isinstance(tweet, dict):
+            return
+        text = clean_required_text(tweet.get("text"))
+        author_id = clean_required_text(tweet.get("author_id"))
+        username = expanded_username(payload, author_id)
+        if not text or not author_id or not username:
+            return
 
-        self.db.tweets.insert({
+        self.db.tweets.insert_one({
             "text": text,
             "date": datetime.datetime.now(datetime.timezone.utc),
-            "screen_name": screen_name,
+            "screen_name": username,
         })
-        return True
 
-    def on_error(self, status_code):
-        if status_code == 420:
-            return False
-        return True  # Don't kill the stream
-
-    def on_timeout(self):
-        return True  # Don't kill the stream
+    def on_request_error(self, status_code):
+        if status_code in (420, 429):
+            self.disconnect()
 
 
-def create_stream(api):
-    return tweepy.streaming.Stream(api.auth, CustomStreamListener(api))
+def create_stream(mongo_client=None):
+    return OscarsStream(config.bearer_token(), mongo_client=mongo_client)
 
 
-def start_stream(track_terms=None):
+def start_stream(track_terms=None, mongo_client=None):
     cleaned_track_terms = clean_track_terms(track_terms)
-    api = create_api()
-    streaming_api = create_stream(api)
-    streaming_api.filter(track=cleaned_track_terms)
-    return streaming_api
+    rule_value = stream_rule_value(cleaned_track_terms)
+    stream = create_stream(mongo_client=mongo_client)
+    sync_stream_rule(stream, rule_value)
+    stream.filter(expansions=["author_id"], user_fields=["username"])
+    return stream
 
 
 if __name__ == "__main__":

--- a/sample_stream.py
+++ b/sample_stream.py
@@ -84,6 +84,8 @@ class CustomStreamListener(tweepy.StreamListener):
         return True
 
     def on_error(self, status_code):
+        if status_code == 420:
+            return False
         return True  # Don't kill the stream
 
     def on_timeout(self):

--- a/sample_stream.py
+++ b/sample_stream.py
@@ -68,7 +68,9 @@ def tagged_rule_ids(rules):
 def sync_stream_rule(stream, rule_value):
     current = stream.get_rules().data or []
     existing_ids = tagged_rule_ids(current)
-    stream.add_rules(tweepy.StreamRule(value=rule_value, tag=RULE_TAG))
+    result = stream.add_rules(tweepy.StreamRule(value=rule_value, tag=RULE_TAG))
+    if result.errors or not result.data:
+        raise RuntimeError("Twitter/X rejected the replacement stream rule")
     if existing_ids:
         stream.delete_rules(existing_ids)
 

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -12,9 +12,11 @@ ROOT = Path(__file__).resolve().parents[1]
 PLAN = "docs/plans/2026-06-08-oscars-stream-baseline.md"
 HOSTED_VALIDATION_PLAN = "docs/plans/2026-06-10-hosted-no-network-validation.md"
 RATE_LIMIT_DISCONNECT_PLAN = "docs/plans/2026-06-12-stream-rate-limit-disconnect.md"
+MODERN_DEPENDENCIES_PLAN = "docs/plans/2026-06-12-modern-stream-dependencies.md"
 REQUIRED = [
     ".github/workflows/check.yml",
     ".gitignore",
+    "AGENTS.md",
     "CHANGES.md",
     "Makefile",
     "Procfile",
@@ -36,7 +38,9 @@ REQUIRED = [
     "docs/plans/2026-06-10-bounded-track-term-preflight.md",
     HOSTED_VALIDATION_PLAN,
     RATE_LIMIT_DISCONNECT_PLAN,
+    MODERN_DEPENDENCIES_PLAN,
     "requirements.txt",
+    "requirements.lock",
     "sample_stream.py",
     "scripts/check-baseline.py",
     "test_sample_stream.py",
@@ -70,26 +74,32 @@ def main():
     config = read("config.py")
     if "ENV[" in config:
         failures.append("config.py must use os.environ instead of undefined ENV")
-    for phrase in ["required_env", "consumer_key", "CONSUMER_KEY", "MONGOHQ_URL", "MONGO_URL", "value.strip()"]:
+    for phrase in ["required_env", "bearer_token", "BEARER_TOKEN", "MONGOHQ_URL", "MONGO_URL", "value.strip()"]:
         if phrase not in config:
             failures.append(f"config.py must include {phrase}")
 
     stream = read("sample_stream.py")
     for phrase in [
         "TRACK_TERMS = [\"#oscars\"]",
-        "def create_api",
         "def create_stream",
         "def start_stream",
         "def clean_required_text",
         "def clean_track_terms",
+        "def stream_rule_value",
+        "def sync_stream_rule",
+        "def expanded_username",
+        "class OscarsStream(tweepy.StreamingClient)",
         "MAX_TRACK_TERMS = 100",
+        "MAX_RULE_LENGTH = 512",
+        'RULE_TAG = "oscars-sample-stream"',
         "cleaned_track_terms = clean_track_terms(track_terms)",
         "track_terms must not include more than 100 values",
+        "track_terms produce a stream rule larger than 512 bytes",
         "isinstance(track_terms, str)",
-        "streaming_api.filter",
+        'stream.filter(expansions=["author_id"], user_fields=["username"])',
         "if __name__ == \"__main__\"",
-        "isinstance(data, dict)",
-        "isinstance(user, dict)",
+        "isinstance(payload, dict)",
+        "isinstance(tweet, dict)",
         "value.strip()",
         "datetime.timezone.utc",
         "track_terms must include at least one non-empty string",
@@ -98,37 +108,39 @@ def main():
         "except TypeError",
         "except (TypeError, ValueError)",
         "mongo_client is not None",
-        "if status_code == 420",
-        "return False",
+        "config.mongo_url()",
+        "config.bearer_token()",
+        "self.db.tweets.insert_one",
+        "if status_code in (420, 429)",
+        "self.disconnect()",
+        "tweepy.StreamRule(value=rule_value, tag=RULE_TAG)",
+        "stream.delete_rules(existing_ids)",
     ]:
         if phrase not in stream:
             failures.append(f"sample_stream.py must include {phrase}")
     if "straming_api" in stream:
         failures.append("sample_stream.py must not contain the stream startup typo")
+    for retired in ["OAuthHandler", "StreamListener", "tweepy.streaming.Stream", ".tweets.insert("]:
+        if retired in stream:
+            failures.append(f"sample_stream.py must not restore retired API {retired}")
 
     tests = read("test_sample_stream.py")
     for phrase in [
-        "FakeOAuthHandler",
+        "FakeStreamingClient",
+        "FakeStreamRule",
         "FakeMongoClient",
-        "test_config_ignores_blank_env_values_and_uses_fallback",
-        "test_start_stream_filters_for_oscars",
-        "bad user",
-        "bad name",
-        "text\":123",
-        "listener.on_data(None)",
-        "[]",
+        "test_config_ignores_blank_bearer_token_and_uses_fallback",
+        "test_start_stream_configures_tagged_oscars_rule",
+        "test_start_stream_replaces_only_worker_tagged_rules",
+        "test_rule_terms_are_literal_and_bounded",
         "test_start_stream_accepts_single_custom_track_term",
-        "test_start_stream_trims_custom_track_terms",
-        "test_start_stream_rejects_empty_custom_track_terms",
-        "test_start_stream_rejects_non_iterable_custom_track_terms",
-        "test_start_stream_rejects_mapping_custom_track_terms",
+        "test_start_stream_rejects_invalid_track_terms_before_client_setup",
         "UserDict",
         "FalsyMongoClient",
-        "test_listener_uses_explicit_falsy_mongo_client",
-        "test_listener_disconnects_on_stream_rate_limit",
-        "test_listener_continues_on_other_stream_errors",
-        "test_listener_continues_after_timeout",
-        "test_start_stream_validates_track_terms_before_client_setup",
+        "test_stream_uses_explicit_falsy_mongo_client",
+        "test_stream_disconnects_on_rate_limits_only",
+        "test_stream_inserts_minimal_v2_tweet_document",
+        "test_stream_ignores_malformed_or_incomplete_v2_payloads",
         "test_start_stream_rejects_more_than_one_hundred_track_terms",
     ]:
         if phrase not in tests:
@@ -157,9 +169,32 @@ def main():
         'python-version: ["3.10", "3.12"]',
         "PYTHONDONTWRITEBYTECODE: \"1\"",
         "run: make check",
+        "dependency-audit:",
+        "pip-audit==2.10.0",
+        "pip-audit -r requirements.lock",
+        "python -m pip install --disable-pip-version-check -r requirements.lock",
     ]:
         if expected not in workflow:
             failures.append(f"Check workflow must keep {expected}")
+    if workflow.count("persist-credentials: false") != 2:
+        failures.append("Check workflow must disable persisted credentials for both jobs")
+
+    requirements = read("requirements.txt")
+    if requirements != "pymongo==4.17.0\ntweepy==4.16.0\n":
+        failures.append("requirements.txt must keep exact maintained Tweepy and PyMongo pins")
+    expected_lock = """certifi==2026.5.20
+charset-normalizer==3.4.7
+dnspython==2.8.0
+idna==3.18
+oauthlib==3.3.1
+pymongo==4.17.0
+requests==2.34.2
+requests-oauthlib==2.0.0
+tweepy==4.16.0
+urllib3==2.7.0
+"""
+    if read("requirements.lock") != expected_lock:
+        failures.append("requirements.lock must keep the exact audited production graph")
 
     gitignore = read(".gitignore")
     for phrase in [".env", ".env.*", "__pycache__/", "*.log", "tmp/"]:
@@ -180,6 +215,7 @@ def main():
         "#oscars",
         "no-network tests",
         "Twitter credentials",
+        "bearer token",
         "required stream fields",
         "blank environment values",
         "custom stream filters",
@@ -194,6 +230,10 @@ def main():
         "bounded track term preflight",
         "stream rate-limit",
         "hosted Linux",
+        "StreamingClient",
+        "insert_one",
+        "oscars-sample-stream",
+        "dependency audit",
     ]:
         if phrase.lower() not in docs.lower():
             failures.append(f"docs must mention {phrase}")
@@ -268,6 +308,29 @@ def main():
     ]:
         if evidence not in disconnect_verification:
             failures.append(f"stream rate-limit disconnect verification must record {evidence}")
+
+    modern_plan = read(MODERN_DEPENDENCIES_PLAN)
+    modern_status = re.findall(r"(?mi)^status:\s*(.+?)\s*$", modern_plan)
+    modern_work = markdown_section(modern_plan, "Work Completed")
+    modern_verification = markdown_section(modern_plan, "Verification Completed")
+    if modern_status != ["completed"] or not modern_work:
+        failures.append("modern dependency plan must record one completed status and completed work")
+    if not modern_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run)\b", modern_verification
+    ):
+        failures.append("modern dependency plan must record completed verification")
+    for evidence in [
+        "Tweepy 4.16.0",
+        "PyMongo 4.17.0",
+        "pip-audit -r requirements.lock",
+        "no known vulnerabilities",
+        "11 no-network tests",
+        "oscars-sample-stream",
+        "insert_one",
+        "420/429 disconnects",
+    ]:
+        if evidence not in modern_verification and evidence not in modern_work:
+            failures.append(f"modern dependency plan must record {evidence}")
 
     try:
         ET.parse(ROOT / "docs/readme-overview.svg")

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -10,6 +10,7 @@ import xml.etree.ElementTree as ET
 ROOT = Path(__file__).resolve().parents[1]
 PLAN = "docs/plans/2026-06-08-oscars-stream-baseline.md"
 HOSTED_VALIDATION_PLAN = "docs/plans/2026-06-10-hosted-no-network-validation.md"
+RATE_LIMIT_DISCONNECT_PLAN = "docs/plans/2026-06-12-stream-rate-limit-disconnect.md"
 REQUIRED = [
     ".github/workflows/check.yml",
     ".gitignore",
@@ -33,6 +34,7 @@ REQUIRED = [
     "docs/plans/2026-06-10-explicit-mongo-client-injection.md",
     "docs/plans/2026-06-10-bounded-track-term-preflight.md",
     HOSTED_VALIDATION_PLAN,
+    RATE_LIMIT_DISCONNECT_PLAN,
     "requirements.txt",
     "sample_stream.py",
     "scripts/check-baseline.py",
@@ -87,6 +89,8 @@ def main():
         "except TypeError",
         "except (TypeError, ValueError)",
         "mongo_client is not None",
+        "if status_code == 420",
+        "return False",
     ]:
         if phrase not in stream:
             failures.append(f"sample_stream.py must include {phrase}")
@@ -112,6 +116,9 @@ def main():
         "UserDict",
         "FalsyMongoClient",
         "test_listener_uses_explicit_falsy_mongo_client",
+        "test_listener_disconnects_on_stream_rate_limit",
+        "test_listener_continues_on_other_stream_errors",
+        "test_listener_continues_after_timeout",
         "test_start_stream_validates_track_terms_before_client_setup",
         "test_start_stream_rejects_more_than_one_hundred_track_terms",
     ]:
@@ -176,6 +183,7 @@ def main():
         "Python bytecode",
         "explicit MongoDB client injection",
         "bounded track term preflight",
+        "stream rate-limit",
         "hosted Linux",
     ]:
         if phrase.lower() not in docs.lower():
@@ -221,6 +229,13 @@ def main():
     hosted_validation_plan = read(HOSTED_VALIDATION_PLAN)
     if "status: completed" not in hosted_validation_plan or "make check" not in hosted_validation_plan:
         failures.append("hosted no-network validation plan must record completed status and verification")
+    rate_limit_disconnect_plan = read(RATE_LIMIT_DISCONNECT_PLAN)
+    if (
+        "status: completed" not in rate_limit_disconnect_plan
+        or "status `420`" not in rate_limit_disconnect_plan
+        or "make check" not in rate_limit_disconnect_plan
+    ):
+        failures.append("stream rate-limit disconnect plan must record completed status and verification")
 
     try:
         ET.parse(ROOT / "docs/readme-overview.svg")

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -328,6 +328,10 @@ urllib3==2.7.0
         "oscars-sample-stream",
         "insert_one",
         "420/429 disconnects",
+        "27431091719",
+        "27431172948",
+        "a987924593313554ed3d55c0bd8cfe388e7c3a93",
+        "zero annotations",
     ]:
         if evidence not in modern_verification and evidence not in modern_work:
             failures.append(f"modern dependency plan must record {evidence}")

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -115,6 +115,8 @@ def main():
         "self.disconnect()",
         "tweepy.StreamRule(value=rule_value, tag=RULE_TAG)",
         "stream.delete_rules(existing_ids)",
+        "if result.errors or not result.data",
+        "Twitter/X rejected the replacement stream rule",
     ]:
         if phrase not in stream:
             failures.append(f"sample_stream.py must include {phrase}")
@@ -132,6 +134,7 @@ def main():
         "test_config_ignores_blank_bearer_token_and_uses_fallback",
         "test_start_stream_configures_tagged_oscars_rule",
         "test_start_stream_replaces_only_worker_tagged_rules",
+        "test_rejected_replacement_rule_preserves_existing_rule",
         "test_rule_terms_are_literal_and_bounded",
         "test_start_stream_accepts_single_custom_track_term",
         "test_start_stream_rejects_invalid_track_terms_before_client_setup",
@@ -324,7 +327,7 @@ urllib3==2.7.0
         "PyMongo 4.17.0",
         "pip-audit -r requirements.lock",
         "no known vulnerabilities",
-        "11 no-network tests",
+        "12 no-network tests",
         "oscars-sample-stream",
         "insert_one",
         "420/429 disconnects",

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 import ast
+import re
 import sys
 import xml.etree.ElementTree as ET
 
@@ -44,6 +45,14 @@ REQUIRED = [
 
 def read(path):
     return (ROOT / path).read_text(encoding="utf-8", errors="replace")
+
+
+def markdown_section(text, heading):
+    match = re.search(
+        rf"(?ms)^## {re.escape(heading)}\s*$\n(.*?)(?=^## |\Z)",
+        text,
+    )
+    return match.group(1).strip() if match else ""
 
 
 def main():
@@ -230,12 +239,35 @@ def main():
     if "status: completed" not in hosted_validation_plan or "make check" not in hosted_validation_plan:
         failures.append("hosted no-network validation plan must record completed status and verification")
     rate_limit_disconnect_plan = read(RATE_LIMIT_DISCONNECT_PLAN)
-    if (
-        "status: completed" not in rate_limit_disconnect_plan
-        or "status `420`" not in rate_limit_disconnect_plan
-        or "make check" not in rate_limit_disconnect_plan
+    disconnect_status = re.findall(r"(?mi)^status:\s*(.+?)\s*$", rate_limit_disconnect_plan)
+    disconnect_work = markdown_section(rate_limit_disconnect_plan, "Work Completed")
+    disconnect_verification = markdown_section(rate_limit_disconnect_plan, "Verification Completed")
+    if disconnect_status != ["completed"] or not disconnect_work:
+        failures.append("stream rate-limit disconnect plan must record one completed status and completed work")
+    if not disconnect_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run)\b", disconnect_verification
     ):
-        failures.append("stream rate-limit disconnect plan must record completed status and verification")
+        failures.append("stream rate-limit disconnect plan must record completed verification")
+    for evidence in [
+        "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_sample_stream.py",
+        "make lint",
+        "make test",
+        "make build",
+        "make check",
+        "git diff --check",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "27398483979",
+        "27398488269",
+        "49fa4143965b1f5081d9288f73756bcb7096075d",
+        "Python `3.10`",
+        "Python `3.12`",
+        "test_listener_disconnects_on_stream_rate_limit",
+        "self.assertFalse(listener.on_error(420))",
+        "test_listener_continues_on_other_stream_errors",
+        "test_listener_continues_after_timeout",
+    ]:
+        if evidence not in disconnect_verification:
+            failures.append(f"stream rate-limit disconnect verification must record {evidence}")
 
     try:
         ET.parse(ROOT / "docs/readme-overview.svg")

--- a/test_sample_stream.py
+++ b/test_sample_stream.py
@@ -195,6 +195,27 @@ class SampleStreamTest(unittest.TestCase):
 
         self.assertIs(client.TweetDB, listener.db)
 
+    def test_listener_disconnects_on_stream_rate_limit(self):
+        sample_stream = load_sample_stream()
+        client = FakeMongoClient("mongodb://example.invalid/db")
+        listener = sample_stream.CustomStreamListener(api=object(), mongo_client=client)
+
+        self.assertFalse(listener.on_error(420))
+
+    def test_listener_continues_on_other_stream_errors(self):
+        sample_stream = load_sample_stream()
+        client = FakeMongoClient("mongodb://example.invalid/db")
+        listener = sample_stream.CustomStreamListener(api=object(), mongo_client=client)
+
+        self.assertTrue(listener.on_error(500))
+
+    def test_listener_continues_after_timeout(self):
+        sample_stream = load_sample_stream()
+        client = FakeMongoClient("mongodb://example.invalid/db")
+        listener = sample_stream.CustomStreamListener(api=object(), mongo_client=client)
+
+        self.assertTrue(listener.on_timeout())
+
     def test_listener_ignores_malformed_or_incomplete_payloads(self):
         sample_stream = load_sample_stream()
         client = FakeMongoClient("mongodb://example.invalid/db")

--- a/test_sample_stream.py
+++ b/test_sample_stream.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 import os
 import sys
 import types
@@ -6,42 +7,49 @@ import unittest
 from collections import UserDict
 
 
-class FakeOAuthHandler:
-    def __init__(self, consumer_key, consumer_secret):
-        self.consumer_key = consumer_key
-        self.consumer_secret = consumer_secret
-        self.access_key = None
-        self.access_secret = None
-
-    def set_access_token(self, access_key, access_secret):
-        self.access_key = access_key
-        self.access_secret = access_secret
+class FakeStreamRule:
+    def __init__(self, value=None, tag=None, id=None):
+        self.value = value
+        self.tag = tag
+        self.id = id
 
 
-class FakeAPI:
-    def __init__(self, auth):
-        self.auth = auth
+class FakeStreamingClient:
+    initial_rules = []
 
+    def __init__(self, bearer_token, **options):
+        self.bearer_token = bearer_token
+        self.options = options
+        self.deleted_rule_ids = []
+        self.added_rules = []
+        self.filter_options = None
+        self.disconnected = False
+        self.rules = list(self.initial_rules)
+        self.rule_operations = []
 
-class FakeStreamListener:
-    pass
+    def get_rules(self):
+        return types.SimpleNamespace(data=self.rules)
 
+    def delete_rules(self, ids):
+        self.deleted_rule_ids.extend(ids)
+        self.rule_operations.append("delete")
 
-class FakeStream:
-    def __init__(self, auth, listener):
-        self.auth = auth
-        self.listener = listener
-        self.filtered_track = None
+    def add_rules(self, rules):
+        self.added_rules.append(rules)
+        self.rule_operations.append("add")
 
-    def filter(self, track):
-        self.filtered_track = track
+    def filter(self, **options):
+        self.filter_options = options
+
+    def disconnect(self):
+        self.disconnected = True
 
 
 class FakeTweets:
     def __init__(self):
         self.documents = []
 
-    def insert(self, document):
+    def insert_one(self, document):
         self.documents.append(document)
 
 
@@ -56,26 +64,12 @@ class FalsyMongoClient(FakeMongoClient):
         return False
 
 
-ENV_NAMES = [
-    "consumer_key",
-    "consumer_secret",
-    "access_key",
-    "access_secret",
-    "MONGOHQ_URL",
-    "CONSUMER_KEY",
-    "CONSUMER_SECRET",
-    "ACCESS_KEY",
-    "ACCESS_SECRET",
-    "MONGO_URL",
-]
+ENV_NAMES = ["bearer_token", "BEARER_TOKEN", "MONGOHQ_URL", "MONGO_URL"]
 
 
-def load_sample_stream(overrides=None):
+def load_sample_stream(overrides=None, rules=None):
     values = {
-        "consumer_key": "consumer",
-        "consumer_secret": "consumer-secret",
-        "access_key": "access",
-        "access_secret": "access-secret",
+        "bearer_token": "bearer",
         "MONGOHQ_URL": "mongodb://example.invalid/db",
     }
     if overrides:
@@ -86,72 +80,74 @@ def load_sample_stream(overrides=None):
     for key, value in values.items():
         os.environ[key] = value
 
-    fake_tweepy = types.SimpleNamespace(
-        OAuthHandler=FakeOAuthHandler,
-        API=FakeAPI,
-        StreamListener=FakeStreamListener,
-        streaming=types.SimpleNamespace(Stream=FakeStream),
+    FakeStreamingClient.initial_rules = list(rules or [])
+    sys.modules["tweepy"] = types.SimpleNamespace(
+        StreamingClient=FakeStreamingClient,
+        StreamRule=FakeStreamRule,
     )
-    fake_pymongo = types.SimpleNamespace(MongoClient=FakeMongoClient)
-    sys.modules["tweepy"] = fake_tweepy
-    sys.modules["pymongo"] = fake_pymongo
+    sys.modules["pymongo"] = types.SimpleNamespace(MongoClient=FakeMongoClient)
 
     for module_name in ["config", "sample_stream"]:
         sys.modules.pop(module_name, None)
     return importlib.import_module("sample_stream")
 
 
+def stream_payload(text="  hello oscars  ", author_id="42", username=" academy "):
+    return json.dumps({
+        "data": {"id": "100", "text": text, "author_id": author_id},
+        "includes": {"users": [{"id": author_id, "username": username}]},
+    })
+
+
 class SampleStreamTest(unittest.TestCase):
-    def test_start_stream_filters_for_oscars(self):
+    def test_start_stream_configures_tagged_oscars_rule(self):
         sample_stream = load_sample_stream()
 
         stream = sample_stream.start_stream()
 
-        self.assertEqual(["#oscars"], stream.filtered_track)
+        self.assertEqual("bearer", stream.bearer_token)
+        self.assertEqual("#oscars", stream.added_rules[0].value)
+        self.assertEqual("oscars-sample-stream", stream.added_rules[0].tag)
+        self.assertEqual(
+            {"expansions": ["author_id"], "user_fields": ["username"]},
+            stream.filter_options,
+        )
 
-    def test_start_stream_trims_custom_track_terms(self):
+    def test_start_stream_replaces_only_worker_tagged_rules(self):
+        rules = [
+            FakeStreamRule(id="ours", tag="oscars-sample-stream"),
+            FakeStreamRule(id="theirs", tag="another-worker"),
+        ]
+        sample_stream = load_sample_stream(rules=rules)
+
+        stream = sample_stream.start_stream([" #oscars2026 ", "best picture"])
+
+        self.assertEqual(["ours"], stream.deleted_rule_ids)
+        self.assertEqual('#oscars2026 OR "best picture"', stream.added_rules[0].value)
+        self.assertEqual(["add", "delete"], stream.rule_operations)
+
+    def test_rule_terms_are_literal_and_bounded(self):
         sample_stream = load_sample_stream()
 
-        stream = sample_stream.start_stream([" #oscars2026 ", "", "best picture"])
-
-        self.assertEqual(["#oscars2026", "best picture"], stream.filtered_track)
+        self.assertEqual('"oscars OR awards"', sample_stream.stream_rule_value(["oscars OR awards"]))
+        self.assertEqual('"best \\"picture\\""', sample_stream.stream_rule_value(['best "picture"']))
+        with self.assertRaisesRegex(ValueError, "larger than 512 bytes"):
+            sample_stream.start_stream(["x" * 513])
 
     def test_start_stream_accepts_single_custom_track_term(self):
         sample_stream = load_sample_stream()
 
         stream = sample_stream.start_stream(" #oscars2026 ")
 
-        self.assertEqual(["#oscars2026"], stream.filtered_track)
+        self.assertEqual("#oscars2026", stream.added_rules[0].value)
 
-    def test_start_stream_rejects_empty_custom_track_terms(self):
+    def test_start_stream_rejects_invalid_track_terms_before_client_setup(self):
         sample_stream = load_sample_stream()
-
-        with self.assertRaises(ValueError):
-            sample_stream.start_stream([" ", 123, None])
-
-    def test_start_stream_rejects_non_iterable_custom_track_terms(self):
-        sample_stream = load_sample_stream()
-
-        with self.assertRaises(ValueError):
-            sample_stream.start_stream(123)
-
-    def test_start_stream_rejects_mapping_custom_track_terms(self):
-        sample_stream = load_sample_stream()
-
-        with self.assertRaises(ValueError):
-            sample_stream.start_stream({"track": "#oscars"})
-        with self.assertRaises(ValueError):
-            sample_stream.start_stream(UserDict({"track": "#oscars"}))
-
-    def test_start_stream_validates_track_terms_before_client_setup(self):
-        sample_stream = load_sample_stream()
-
-        def fail_create_api():
-            self.fail("invalid track terms reached API client setup")
-
-        sample_stream.create_api = fail_create_api
-        with self.assertRaises(ValueError):
-            sample_stream.start_stream([" "])
+        for key in ENV_NAMES:
+            os.environ.pop(key, None)
+        for invalid in ([" ", 123, None], 123, {"track": "#oscars"}, UserDict({"track": "#oscars"})):
+            with self.subTest(invalid=invalid), self.assertRaises(ValueError):
+                sample_stream.start_stream(invalid)
 
     def test_start_stream_rejects_more_than_one_hundred_track_terms(self):
         sample_stream = load_sample_stream()
@@ -160,75 +156,70 @@ class SampleStreamTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "more than 100"):
             sample_stream.start_stream(track_terms)
 
-    def test_config_ignores_blank_env_values_and_uses_fallback(self):
+    def test_config_ignores_blank_bearer_token_and_uses_fallback(self):
         sample_stream = load_sample_stream(
-            {
-                "consumer_key": "   ",
-                "CONSUMER_KEY": "consumer-fallback",
-            }
+            {"bearer_token": "   ", "BEARER_TOKEN": "bearer-fallback"}
         )
 
-        self.assertEqual("consumer-fallback", sample_stream.config.consumer_key)
+        self.assertEqual("bearer-fallback", sample_stream.config.bearer_token())
 
-    def test_listener_inserts_minimal_tweet_document(self):
+    def test_stream_inserts_minimal_v2_tweet_document(self):
         sample_stream = load_sample_stream()
         client = FakeMongoClient("mongodb://example.invalid/db")
-        listener = sample_stream.CustomStreamListener(api=object(), mongo_client=client)
+        stream = sample_stream.OscarsStream("bearer", mongo_client=client)
 
-        keep_streaming = listener.on_data(
-            '{"text":"  hello oscars  ","user":{"screen_name":" academy "}}'
-        )
+        stream.on_data(stream_payload())
 
-        self.assertTrue(keep_streaming)
         self.assertEqual(1, len(client.TweetDB.tweets.documents))
         document = client.TweetDB.tweets.documents[0]
         self.assertEqual("hello oscars", document["text"])
         self.assertEqual("academy", document["screen_name"])
-        self.assertIn("date", document)
         self.assertIsNotNone(document["date"].tzinfo)
 
-    def test_listener_uses_explicit_falsy_mongo_client(self):
+    def test_stream_uses_explicit_falsy_mongo_client(self):
         sample_stream = load_sample_stream()
         client = FalsyMongoClient("mongodb://example.invalid/db")
 
-        listener = sample_stream.CustomStreamListener(api=object(), mongo_client=client)
+        stream = sample_stream.OscarsStream("bearer", mongo_client=client)
 
-        self.assertIs(client.TweetDB, listener.db)
+        self.assertIs(client.TweetDB, stream.db)
 
-    def test_listener_disconnects_on_stream_rate_limit(self):
+    def test_stream_disconnects_on_rate_limits_only(self):
+        sample_stream = load_sample_stream()
+        stream = sample_stream.OscarsStream(
+            "bearer", mongo_client=FakeMongoClient("mongodb://example.invalid/db")
+        )
+
+        stream.on_request_error(500)
+        self.assertFalse(stream.disconnected)
+        stream.on_request_error(429)
+        self.assertTrue(stream.disconnected)
+
+        stream.disconnected = False
+        stream.on_request_error(420)
+        self.assertTrue(stream.disconnected)
+
+    def test_stream_ignores_malformed_or_incomplete_v2_payloads(self):
         sample_stream = load_sample_stream()
         client = FakeMongoClient("mongodb://example.invalid/db")
-        listener = sample_stream.CustomStreamListener(api=object(), mongo_client=client)
+        stream = sample_stream.OscarsStream("bearer", mongo_client=client)
+        invalid_payloads = [
+            "not-json",
+            None,
+            "[]",
+            '{"data":"tweet"}',
+            stream_payload(text=123),
+            stream_payload(author_id=123),
+            stream_payload(username=123),
+            stream_payload(text="   "),
+            '{"data":{"text":"missing author"},"includes":{"users":[]}}',
+            '{"data":{"text":"missing user","author_id":"42"},"includes":{"users":[]}}',
+            '{"data":{"text":"wrong user","author_id":"42"},"includes":{"users":[{"id":"7","username":"academy"}]}}',
+        ]
 
-        self.assertFalse(listener.on_error(420))
-
-    def test_listener_continues_on_other_stream_errors(self):
-        sample_stream = load_sample_stream()
-        client = FakeMongoClient("mongodb://example.invalid/db")
-        listener = sample_stream.CustomStreamListener(api=object(), mongo_client=client)
-
-        self.assertTrue(listener.on_error(500))
-
-    def test_listener_continues_after_timeout(self):
-        sample_stream = load_sample_stream()
-        client = FakeMongoClient("mongodb://example.invalid/db")
-        listener = sample_stream.CustomStreamListener(api=object(), mongo_client=client)
-
-        self.assertTrue(listener.on_timeout())
-
-    def test_listener_ignores_malformed_or_incomplete_payloads(self):
-        sample_stream = load_sample_stream()
-        client = FakeMongoClient("mongodb://example.invalid/db")
-        listener = sample_stream.CustomStreamListener(api=object(), mongo_client=client)
-
-        self.assertTrue(listener.on_data("not-json"))
-        self.assertTrue(listener.on_data(None))
-        self.assertTrue(listener.on_data("[]"))
-        self.assertTrue(listener.on_data('{"text":"bad user","user":"academy"}'))
-        self.assertTrue(listener.on_data('{"text":123,"user":{"screen_name":"academy"}}'))
-        self.assertTrue(listener.on_data('{"text":"bad name","user":{"screen_name":123}}'))
-        self.assertTrue(listener.on_data('{"text":"   ","user":{"screen_name":"academy"}}'))
-        self.assertTrue(listener.on_data('{"text":"missing user"}'))
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                stream.on_data(payload)
         self.assertEqual([], client.TweetDB.tweets.documents)
 
 

--- a/test_sample_stream.py
+++ b/test_sample_stream.py
@@ -16,6 +16,7 @@ class FakeStreamRule:
 
 class FakeStreamingClient:
     initial_rules = []
+    add_errors = None
 
     def __init__(self, bearer_token, **options):
         self.bearer_token = bearer_token
@@ -37,6 +38,10 @@ class FakeStreamingClient:
     def add_rules(self, rules):
         self.added_rules.append(rules)
         self.rule_operations.append("add")
+        return types.SimpleNamespace(
+            data=None if self.add_errors else [FakeStreamRule(id="new", tag=rules.tag)],
+            errors=self.add_errors,
+        )
 
     def filter(self, **options):
         self.filter_options = options
@@ -81,6 +86,7 @@ def load_sample_stream(overrides=None, rules=None):
         os.environ[key] = value
 
     FakeStreamingClient.initial_rules = list(rules or [])
+    FakeStreamingClient.add_errors = None
     sys.modules["tweepy"] = types.SimpleNamespace(
         StreamingClient=FakeStreamingClient,
         StreamRule=FakeStreamRule,
@@ -125,6 +131,22 @@ class SampleStreamTest(unittest.TestCase):
         self.assertEqual(["ours"], stream.deleted_rule_ids)
         self.assertEqual('#oscars2026 OR "best picture"', stream.added_rules[0].value)
         self.assertEqual(["add", "delete"], stream.rule_operations)
+
+    def test_rejected_replacement_rule_preserves_existing_rule(self):
+        rules = [FakeStreamRule(id="ours", tag="oscars-sample-stream")]
+        sample_stream = load_sample_stream(rules=rules)
+        FakeStreamingClient.add_errors = [{"message": "invalid rule"}]
+
+        with self.assertRaisesRegex(RuntimeError, "rejected the replacement"):
+            sample_stream.start_stream()
+
+        stream = sample_stream.OscarsStream("bearer", mongo_client=FakeMongoClient("mongodb://example.invalid/db"))
+        stream.rules = rules
+        FakeStreamingClient.add_errors = [{"message": "invalid rule"}]
+        with self.assertRaises(RuntimeError):
+            sample_stream.sync_stream_rule(stream, "#oscars")
+        self.assertEqual([], stream.deleted_rule_ids)
+        self.assertEqual(["add"], stream.rule_operations)
 
     def test_rule_terms_are_literal_and_bounded(self):
         sample_stream = load_sample_stream()


### PR DESCRIPTION
## Summary

Modernize the Oscars stream worker from vulnerable Tweepy 2.2 and PyMongo 2.6.3 APIs to maintained releases, with an explicit Twitter/X API v2 compatibility migration.

This cumulative PR includes the completed bounded-filter and rate-limit-disconnect work from PRs #4 and #5; those existing PRs remain open and unchanged.

## Baseline

- The worker depended on vulnerable Tweepy 2.2 and PyMongo 2.6.3 releases and the retired Twitter API v1.1 listener contract.
- The default branch still reports two Dependabot alerts until an approved remediation PR is merged.
- No isolated Twitter/X API v2 project, bearer token, or MongoDB environment was available for a live integration test.

## Improvements

- Pin Tweepy 4.16.0 and PyMongo 4.17.0, plus an exact ten-package production lock.
- Replace the retired v1.1 listener with a lazily configured bearer-token `StreamingClient`.
- Build bounded literal API v2 rules and replace only rules tagged `oscars-sample-stream`.
- Require confirmed API creation of the replacement rule before deleting prior tagged rules; API-level rejections preserve the existing filter.
- Request author expansion and store only normalized text plus the matching username.
- Move Mongo writes to `insert_one` while preserving explicit falsy-client injection.
- Disconnect on stream rate limits 420 and 429.
- Install the lock in the Python 3.10/3.12 matrix and audit the resolved graph in a separate pinned job.

## Validation

- Clean resolved install and `pip check`: passed.
- Credential-free real import smoke: Tweepy 4.16.0 `StreamingClient` and PyMongo 4.17.0 passed.
- `make lint`, `make test`, `make build`, and `make check`: passed with 12 no-network tests.
- `pip-audit -r requirements.lock`: no known vulnerabilities.
- Python compilation, workflow parse, and `git diff --check`: passed.
- Eleven broad hostile mutations plus the API-level add-error bypass mutation were rejected.
- Exact-head push Check run `27431464251`: Python 3.10, Python 3.12, and dependency audit succeeded.
- Exact-head pull-request Check run `27431465488`: Python 3.10, Python 3.12, and dependency audit succeeded.
- Exact-head CodeQL run `27431463800`: Python and Actions analysis succeeded.
- All exact-head check annotations are zero; branch and PR-ref code scanning and repository secret scanning report zero open alerts.
- Exact head `dab71c9f0c22b17e910bd638faf1afffbd713ad9` is pushed, and PR #6 is open, clean, and mergeable against `master`.

## Risk

- No live Twitter/X or MongoDB request was made. A credentialed smoke test still requires an isolated API v2 project and database.
- API v2 filter rules are persistent project-wide state; this implementation limits replacement to the worker's tag, but operators should confirm that tag is reserved for this deployment.
- The worker keeps the historical `screen_name` storage field for downstream compatibility even though its value now comes from API v2 `username`.

## Follow-Ups

- Run a credentialed smoke test against an isolated Twitter/X API v2 project and MongoDB database.
- Confirm that the `oscars-sample-stream` rule tag is reserved for this deployment before production use.
- The two default-branch Dependabot alerts remain visible until this open PR is merged. This PR has not been merged or closed.
