### PR TITLE
feat: add credential-free stream dry run

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-13
+
+- Added a credential-free `--dry-run` path that emits the exact normalized API
+  v2 rule tag and filter options as stable JSON without constructing clients,
+  mutating remote rules, starting a stream, or writing MongoDB documents.
+
 ## 2026-06-12
 
 - Added SHA-256 artifact hashes for production and dependency-audit graphs,

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ python -m pip_audit --require-hashes --no-deps -r requirements.lock
 
 ## Running or Using the Project
 
+- Preview the exact tagged rule and stream options without credentials, remote
+  rule changes, MongoDB access, or network calls:
+
+  ```bash
+  python sample_stream.py --dry-run
+  python sample_stream.py --dry-run --track-term '#oscars2026' --track-term 'best picture'
+  ```
+
+  Dry-run output is stable JSON. It validates the same normalization, term
+  count, quoting, and 512-byte rule limit as live startup, but it does not prove
+  Twitter/X authorization, remote rule state, stream connectivity, or MongoDB
+  access.
 - Configure a Twitter/X API v2 bearer token with `bearer_token` or
   `BEARER_TOKEN`.
 - Configure MongoDB with `MONGOHQ_URL` or `MONGO_URL`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,10 @@ Persistent API v2 rules are project-wide state. The worker may replace only
 rules tagged `oscars-sample-stream`; broad deletion could disrupt unrelated
 stream consumers. Rule expressions are bounded to 512 UTF-8 bytes before
 client setup.
+Use `python sample_stream.py --dry-run` to inspect normalized rule JSON without
+reading bearer-token or MongoDB environment values, constructing clients,
+mutating persistent API v2 rules, starting a stream, or writing documents.
+Dry-run success is not a credentialed connectivity or authorization check.
 Pinned, read-only hosted Linux validation installs hash-locked Tweepy 4.16.0 and PyMongo
 4.17.0, then runs the fake-client baseline on two Python versions without
 credentials, live Twitter calls, or MongoDB access. A separate pinned

--- a/VISION.md
+++ b/VISION.md
@@ -45,10 +45,11 @@ Priority:
 - Keep Python 3.10 and 3.12 hosted Linux validation credential-free and
   no-network
 - Keep production and dependency-audit installs exact and hash-locked
+- Keep credential-free dry-run output aligned with live rule normalization and
+  isolated from client construction, remote state, streaming, and storage
 
 Next priorities:
 
-- Add a dry-run or mock-stream path for local testing
 - Add filter boundary fixtures without expanding collection scope defaults
 - Move configuration examples into environment-variable documentation
 - Document retention and cleanup expectations for stored stream fields

--- a/docs/plans/2026-06-13-dry-run-stream-rule.md
+++ b/docs/plans/2026-06-13-dry-run-stream-rule.md
@@ -1,0 +1,90 @@
+# Dry-Run Stream Rule
+
+status: planned
+
+## Context
+
+The worker can validate custom track terms before client setup, but operators
+still need Twitter/X and MongoDB credentials to exercise the complete startup
+entry point. That makes it unnecessarily difficult to inspect the exact tagged
+API v2 rule and stream options during local setup or deployment review.
+
+## Priorities
+
+1. Provide a deterministic command-line dry run for the exact startup plan.
+2. Prove dry-run mode cannot read credentials, construct clients, mutate remote
+   rules, start filtering, or write MongoDB documents.
+3. Reuse production filter normalization and rule-size validation so dry-run
+   output cannot drift from live startup behavior.
+
+## Requirements
+
+- R1. Add `--dry-run` and repeatable `--track-term` command-line options to the
+  existing worker entry point.
+- R2. Emit one stable JSON object containing the rule tag, normalized rule
+  value, author expansion, and requested user fields.
+- R3. Use the same `clean_track_terms` and `stream_rule_value` path as live
+  startup, including default `#oscars`, literal quoting, count, and byte bounds.
+- R4. Return the same structured plan from a callable helper so tests and local
+  tooling do not need to parse console output.
+- R5. In dry-run mode, do not read bearer-token or MongoDB environment values,
+  create Tweepy or Mongo clients, query/add/delete rules, call `filter`, or
+  write data.
+- R6. Preserve live `start_stream` behavior and the existing default entry
+  point when `--dry-run` is absent.
+- R7. Document credential-free local usage and make clear that dry-run success
+  does not verify live API authorization, remote rule state, or MongoDB access.
+- R8. Extend the no-network tests and baseline checker to prevent dry-run
+  side-effect isolation or completed evidence from being removed silently.
+
+## Implementation Units
+
+### U1: Structured Startup Plan
+
+Files: `sample_stream.py`, `test_sample_stream.py`
+
+Create one helper that normalizes terms and returns the exact rule/options
+shape used by both dry-run output and live stream startup. Keep client creation
+strictly after dry-run branching.
+
+### U2: Command-Line Dry Run
+
+Files: `sample_stream.py`, `test_sample_stream.py`
+
+Add argument parsing and stable JSON output while preserving the current live
+default. Cover defaults, repeated custom terms, invalid terms, deterministic
+output, and explicit proof that credentials and clients are unreachable.
+
+### U3: Operator Guidance And Static Contract
+
+Files: `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`,
+`scripts/check-baseline.py`, `docs/plans/2026-06-13-dry-run-stream-rule.md`
+
+Document the local workflow and residual boundaries, require the implementation
+and tests in the baseline checker, and record completed verification only after
+all gates and hostile mutations pass.
+
+## Verification Plan
+
+- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_sample_stream.py`
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- run `python3 sample_stream.py --dry-run` without credentials in an isolated
+  environment using the locked runtime graph
+- run the checker from an external working directory
+- parse workflow YAML and dependency manifests
+- run focused hostile mutations against dry-run side-effect isolation
+- verify dependencies, workflow, live configuration, payload storage, and
+  remote-rule behavior have no unrelated diff
+- `git diff --check`
+- scan intended paths for secrets and generated artifacts
+
+## Scope Boundaries
+
+- Do not add a mock Twitter server, MongoDB emulator, live smoke test, network
+  call, credential, dependency, or deployment process.
+- Do not broaden the default collection filter or stored document fields.
+- Do not change rule replacement, rate-limit disconnect, payload validation,
+  author expansion, or MongoDB insertion behavior.

--- a/docs/plans/2026-06-13-dry-run-stream-rule.md
+++ b/docs/plans/2026-06-13-dry-run-stream-rule.md
@@ -1,6 +1,6 @@
 # Dry-Run Stream Rule
 
-status: planned
+status: completed
 
 ## Context
 
@@ -88,3 +88,26 @@ all gates and hostile mutations pass.
 - Do not broaden the default collection filter or stored document fields.
 - Do not change rule replacement, rate-limit disconnect, payload validation,
   author expansion, or MongoDB insertion behavior.
+
+## Work Completed
+
+Added a shared structured stream plan, credential-free dry-run branch,
+repeatable track-term CLI, stable JSON output, operator guidance, no-network
+tests, and mutation-sensitive baseline checks without changing live stream or
+storage behavior.
+
+## Verification Completed
+
+- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_sample_stream.py`,
+  `make lint`, `make test`, `make build`, and `make check` passed.
+- `python3 sample_stream.py --dry-run` passed without credentials in an
+  isolated locked runtime environment.
+- The checker passed from an external working directory; workflow YAML and
+  dependency manifests parsed successfully.
+- Ten focused hostile mutations rejected weakened dry-run side-effect,
+  structured-output, test, and completed-plan contracts.
+- `live behavior paths had no unrelated diff`; dependency locks, workflow,
+  configuration loading, payload storage, rule synchronization, and rate-limit
+  handling remained unchanged outside the shared startup-plan wiring.
+- `git diff --check` and the intended-diff secret and generated-artifact scan
+  passed.

--- a/sample_stream.py
+++ b/sample_stream.py
@@ -1,6 +1,8 @@
+import argparse
 import datetime
 import json
 import re
+import sys
 from collections.abc import Mapping
 
 import pymongo
@@ -59,6 +61,16 @@ def stream_rule_value(track_terms):
     if len(value.encode("utf-8")) > MAX_RULE_LENGTH:
         raise ValueError("track_terms produce a stream rule larger than 512 bytes")
     return value
+
+
+def stream_plan(track_terms=None):
+    cleaned_track_terms = clean_track_terms(track_terms)
+    return {
+        "rule_tag": RULE_TAG,
+        "rule_value": stream_rule_value(cleaned_track_terms),
+        "expansions": ["author_id"],
+        "user_fields": ["username"],
+    }
 
 
 def tagged_rule_ids(rules):
@@ -131,14 +143,45 @@ def create_stream(mongo_client=None):
     return OscarsStream(config.bearer_token(), mongo_client=mongo_client)
 
 
-def start_stream(track_terms=None, mongo_client=None):
-    cleaned_track_terms = clean_track_terms(track_terms)
-    rule_value = stream_rule_value(cleaned_track_terms)
+def start_stream(track_terms=None, mongo_client=None, dry_run=False):
+    plan = stream_plan(track_terms)
+    if dry_run:
+        return plan
+
     stream = create_stream(mongo_client=mongo_client)
-    sync_stream_rule(stream, rule_value)
-    stream.filter(expansions=["author_id"], user_fields=["username"])
+    sync_stream_rule(stream, plan["rule_value"])
+    stream.filter(
+        expansions=plan["expansions"],
+        user_fields=plan["user_fields"],
+    )
     return stream
 
 
+def main(argv=None, output=None):
+    parser = argparse.ArgumentParser(description="Run the Oscars API v2 stream worker")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "print the normalized stream rule without reading credentials "
+            "or creating clients"
+        ),
+    )
+    parser.add_argument(
+        "--track-term",
+        action="append",
+        dest="track_terms",
+        help="stream term to include; repeat for multiple terms",
+    )
+    args = parser.parse_args(argv)
+    result = start_stream(track_terms=args.track_terms, dry_run=args.dry_run)
+    if args.dry_run:
+        print(
+            json.dumps(result, sort_keys=True),
+            file=output if output is not None else sys.stdout,
+        )
+    return result
+
+
 if __name__ == "__main__":
-    start_stream()
+    main()

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -15,6 +15,7 @@ HOSTED_VALIDATION_PLAN = "docs/plans/2026-06-10-hosted-no-network-validation.md"
 RATE_LIMIT_DISCONNECT_PLAN = "docs/plans/2026-06-12-stream-rate-limit-disconnect.md"
 MODERN_DEPENDENCIES_PLAN = "docs/plans/2026-06-12-modern-stream-dependencies.md"
 HASH_LOCK_PLAN = "docs/plans/2026-06-12-hash-locked-dependency-installs.md"
+DRY_RUN_PLAN = "docs/plans/2026-06-13-dry-run-stream-rule.md"
 PRODUCTION_LOCK_SHA256 = "27ea76d7d0f7efea504ebcee475e411502bc775dceab3e10501563085d77ce1c"
 AUDIT_LOCK_SHA256 = "fc7ce7c6f13eee2008ea150facb1560903d6d12f4d6ad5245e68fdc3a75e607b"
 REQUIRED = [
@@ -44,6 +45,7 @@ REQUIRED = [
     RATE_LIMIT_DISCONNECT_PLAN,
     MODERN_DEPENDENCIES_PLAN,
     HASH_LOCK_PLAN,
+    DRY_RUN_PLAN,
     "requirements-audit.in",
     "requirements-audit.lock",
     "requirements.txt",
@@ -107,6 +109,8 @@ def main():
         "def clean_required_text",
         "def clean_track_terms",
         "def stream_rule_value",
+        "def stream_plan",
+        "def main",
         "def sync_stream_rule",
         "def expanded_username",
         "class OscarsStream(tweepy.StreamingClient)",
@@ -117,7 +121,14 @@ def main():
         "track_terms must not include more than 100 values",
         "track_terms produce a stream rule larger than 512 bytes",
         "isinstance(track_terms, str)",
-        'stream.filter(expansions=["author_id"], user_fields=["username"])',
+        '"rule_tag": RULE_TAG',
+        '"rule_value": stream_rule_value(cleaned_track_terms)',
+        '"expansions": ["author_id"]',
+        '"user_fields": ["username"]',
+        "if dry_run:",
+        '"--dry-run"',
+        '"--track-term"',
+        "json.dumps(result, sort_keys=True)",
         "if __name__ == \"__main__\"",
         "isinstance(payload, dict)",
         "isinstance(tweet, dict)",
@@ -141,6 +152,20 @@ def main():
     ]:
         if phrase not in stream:
             failures.append(f"sample_stream.py must include {phrase}")
+    start_stream_source = stream[stream.find("def start_stream"):stream.find("def main")]
+    if not (
+        "plan = stream_plan(track_terms)" in start_stream_source
+        and "if dry_run:\n        return plan" in start_stream_source
+        and "stream = create_stream" in start_stream_source
+        and start_stream_source.find("if dry_run:")
+        < start_stream_source.find("stream = create_stream")
+    ):
+        failures.append(
+            "start_stream dry run must return the shared plan before client construction"
+        )
+    main_source = stream[stream.find("def main"):]
+    if "start_stream(track_terms=args.track_terms, dry_run=args.dry_run)" not in main_source:
+        failures.append("CLI must route live and dry-run startup through start_stream")
     if "straming_api" in stream:
         failures.append("sample_stream.py must not contain the stream startup typo")
     for retired in ["OAuthHandler", "StreamListener", "tweepy.streaming.Stream", ".tweets.insert("]:
@@ -163,6 +188,11 @@ def main():
         "FalsyMongoClient",
         "test_stream_uses_explicit_falsy_mongo_client",
         "test_stream_disconnects_on_rate_limits_only",
+        "test_stream_plan_matches_live_rule_and_filter_options",
+        "test_dry_run_returns_default_plan_without_credentials_or_clients",
+        "test_main_dry_run_emits_stable_json_for_repeated_track_terms",
+        "test_main_without_dry_run_preserves_live_startup",
+        "dry run must not construct a Twitter/X or MongoDB client",
         "test_stream_inserts_minimal_v2_tweet_document",
         "test_stream_ignores_malformed_or_incomplete_v2_payloads",
         "test_start_stream_rejects_more_than_one_hundred_track_terms",
@@ -297,6 +327,9 @@ def main():
         "oscars-sample-stream",
         "dependency audit",
         "hash-locked",
+        "credential-free dry-run output",
+        "stable JSON",
+        "does not prove",
     ]:
         if phrase.lower() not in docs.lower():
             failures.append(f"docs must mention {phrase}")
@@ -407,6 +440,34 @@ def main():
         failures.append("hash-lock plan must record one completed status and completed work")
     if not hash_lock_verification or "make check" not in hash_lock_verification:
         failures.append("hash-lock plan must record completed make check verification")
+
+    dry_run_plan = read(DRY_RUN_PLAN)
+    dry_run_status = re.findall(r"(?mi)^status:\s*(.+?)\s*$", dry_run_plan)
+    dry_run_work = markdown_section(dry_run_plan, "Work Completed")
+    dry_run_verification = markdown_section(dry_run_plan, "Verification Completed")
+    if dry_run_status != ["completed"] or not dry_run_work:
+        failures.append("dry-run plan must record one completed status and completed work")
+    if not dry_run_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run)\b", dry_run_verification
+    ):
+        failures.append("dry-run plan must record completed verification")
+    for evidence in [
+        "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_sample_stream.py",
+        "make lint",
+        "make test",
+        "make build",
+        "make check",
+        "python3 sample_stream.py --dry-run",
+        "external working directory",
+        "workflow YAML",
+        "dependency manifests",
+        "hostile mutations rejected",
+        "live behavior paths had no unrelated diff",
+        "git diff --check",
+        "secret and generated-artifact scan",
+    ]:
+        if evidence not in dry_run_verification:
+            failures.append(f"dry-run verification must record {evidence}")
 
     try:
         ET.parse(ROOT / "docs/readme-overview.svg")

--- a/test_sample_stream.py
+++ b/test_sample_stream.py
@@ -1,4 +1,5 @@
 import importlib
+import io
 import json
 import os
 import sys
@@ -106,6 +107,74 @@ def stream_payload(text="  hello oscars  ", author_id="42", username=" academy "
 
 
 class SampleStreamTest(unittest.TestCase):
+    def test_stream_plan_matches_live_rule_and_filter_options(self):
+        sample_stream = load_sample_stream()
+
+        plan = sample_stream.stream_plan([" #oscars2026 ", "best picture"])
+
+        self.assertEqual({
+            "rule_tag": "oscars-sample-stream",
+            "rule_value": '#oscars2026 OR "best picture"',
+            "expansions": ["author_id"],
+            "user_fields": ["username"],
+        }, plan)
+
+        stream = sample_stream.start_stream([" #oscars2026 ", "best picture"])
+        self.assertEqual(plan["rule_value"], stream.added_rules[0].value)
+        self.assertEqual(plan["rule_tag"], stream.added_rules[0].tag)
+        self.assertEqual({
+            "expansions": plan["expansions"],
+            "user_fields": plan["user_fields"],
+        }, stream.filter_options)
+
+    def test_dry_run_returns_default_plan_without_credentials_or_clients(self):
+        sample_stream = load_sample_stream()
+        for key in ENV_NAMES:
+            os.environ.pop(key, None)
+
+        def unexpected_client(*args, **kwargs):
+            self.fail("dry run must not construct a Twitter/X or MongoDB client")
+
+        sample_stream.create_stream = unexpected_client
+
+        self.assertEqual({
+            "rule_tag": "oscars-sample-stream",
+            "rule_value": "#oscars",
+            "expansions": ["author_id"],
+            "user_fields": ["username"],
+        }, sample_stream.start_stream(dry_run=True))
+
+    def test_main_dry_run_emits_stable_json_for_repeated_track_terms(self):
+        sample_stream = load_sample_stream()
+        for key in ENV_NAMES:
+            os.environ.pop(key, None)
+        output = io.StringIO()
+
+        result = sample_stream.main(
+            ["--dry-run", "--track-term", " #oscars2026 ", "--track-term", "best picture"],
+            output=output,
+        )
+
+        expected = {
+            "rule_tag": "oscars-sample-stream",
+            "rule_value": '#oscars2026 OR "best picture"',
+            "expansions": ["author_id"],
+            "user_fields": ["username"],
+        }
+        self.assertEqual(expected, result)
+        self.assertEqual(json.dumps(expected, sort_keys=True) + "\n", output.getvalue())
+
+    def test_main_without_dry_run_preserves_live_startup(self):
+        sample_stream = load_sample_stream()
+
+        stream = sample_stream.main(["--track-term", "#oscars2026"])
+
+        self.assertEqual("#oscars2026", stream.added_rules[0].value)
+        self.assertEqual(
+            {"expansions": ["author_id"], "user_fields": ["username"]},
+            stream.filter_options,
+        )
+
     def test_start_stream_configures_tagged_oscars_rule(self):
         sample_stream = load_sample_stream()
 


### PR DESCRIPTION
## Summary

Operators can now inspect the exact normalized Twitter/X API v2 rule and stream options without credentials, client construction, remote rule mutation, network calls, or MongoDB writes. The dry run shares production normalization and bounds, so its stable JSON reflects what live startup would use without claiming live connectivity.

## Baseline

Local setup previously required entering the live startup path to inspect the effective rule. That path reads credentials, constructs Tweepy and MongoDB clients, mutates persistent project rules, and starts filtering.

## Improvements

- add `--dry-run` and repeatable `--track-term` command-line options
- return one structured startup plan shared by dry-run and live startup
- emit deterministic JSON containing the rule tag, normalized rule value, author expansion, and user fields
- return before credential reads and client construction in dry-run mode
- preserve default live startup and custom-term behavior when `--dry-run` is absent
- document the credential-free workflow and its live-service limitations
- enforce side-effect ordering, CLI wiring, tests, and completed evidence in the static baseline

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_sample_stream.py`: 16 passed
- `make lint`, `make test`, `make build`, and `make check`
- isolated hash-locked Python 3.12 invocation with no credentials:
  `python sample_stream.py --dry-run --track-term '#oscars2026' --track-term 'best picture'`
- checker passed from an external working directory
- workflow YAML and dependency manifests parsed
- 10 focused hostile mutations rejected, including moving client construction before the dry-run guard
- dependency locks, workflow, configuration, process entry, payload storage, rule synchronization, and rate-limit handling audits passed
- no generated artifacts or secret-like additions

## Risk

The worker entry point now parses optional CLI arguments. With no arguments it retains the previous live startup behavior. Dry-run success intentionally does not verify Twitter/X authorization, persistent remote rule state, stream connectivity, or MongoDB access.

## Follow-Ups

### Post-Deploy Monitoring & Validation

- **Window:** repository owner, during the first review/deployment after merge
- **Healthy signal:** `python sample_stream.py --dry-run` exits zero without credential variables and emits a single JSON object with tag `oscars-sample-stream` and rule `#oscars`
- **Custom-rule signal:** repeated `--track-term` values produce the reviewed quoted `OR` expression without network activity
- **Failure signals:** credential errors, connection attempts, MongoDB errors, non-JSON output, changed live default startup, or any remote rule mutation during dry run
- **Logs/search:** inspect worker startup logs for `Missing required environment variable`, connection errors, or unexpected rule mutations only when dry-run commands are exercised
- **Rollback trigger:** any dry-run side effect or live-startup regression; revert `e9fc4c0` and `7510f1a` together

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
