### PR TITLE
Abort on stream rule list errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Abort stream startup before remote mutation when Twitter/X cannot list the
+  project's existing persistent API v2 rules.
 - Added a credential-free `--dry-run` path that emits the exact normalized API
   v2 rule tag and filter options as stable JSON without constructing clients,
   mutating remote rules, starting a stream, or writing MongoDB documents.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ python -m pip_audit --require-hashes --no-deps -r requirements.lock
 - Run `python sample_stream.py` or the Heroku `worker` process from `Procfile`.
 - The default stream filter is `#oscars`. The worker replaces only persistent
   API v2 rules tagged `oscars-sample-stream`; unrelated project rules are not
-  deleted.
+  deleted. If the existing-rule query fails, startup stops before adding,
+  deleting, or filtering so project-wide rule state is not changed blindly.
 - Custom stream filters must contain at least one non-empty string after
   trimming; blank custom stream filters are rejected instead of silently using
   the default.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,7 +65,8 @@ verification gates.
 Persistent API v2 rules are project-wide state. The worker may replace only
 rules tagged `oscars-sample-stream`; broad deletion could disrupt unrelated
 stream consumers. Rule expressions are bounded to 512 UTF-8 bytes before
-client setup.
+client setup. A failed existing-rule query aborts startup before add, delete,
+or filter operations rather than treating unknown project state as empty.
 Use `python sample_stream.py --dry-run` to inspect normalized rule JSON without
 reading bearer-token or MongoDB environment values, constructing clients,
 mutating persistent API v2 rules, starting a stream, or writing documents.

--- a/VISION.md
+++ b/VISION.md
@@ -40,6 +40,7 @@ Priority:
 - Keep explicit MongoDB client injection reliable for no-network tests
 - Keep API v2 stream rate-limit errors from reconnecting indefinitely
 - Keep rule replacement scoped to the `oscars-sample-stream` tag
+- Keep failed persistent-rule discovery ahead of add, delete, and filter calls
 - Require expanded author identity before MongoDB storage through `insert_one`
 - Keep verification targets from leaving Python bytecode behind
 - Keep Python 3.10 and 3.12 hosted Linux validation credential-free and

--- a/docs/plans/2026-06-13-stream-rule-list-error-boundary.md
+++ b/docs/plans/2026-06-13-stream-rule-list-error-boundary.md
@@ -1,6 +1,6 @@
 # Stream Rule List Error Boundary
 
-status: pending
+status: completed
 
 ## Context
 
@@ -26,8 +26,23 @@ rule already exists.
 
 ## Work Completed
 
-Pending implementation.
+- Added an explicit rule-list response error boundary before tagged-rule
+  selection, replacement creation, deletion, and stream filtering.
+- Extended the fake streaming client and no-network suite to force a list
+  failure through live startup and assert zero add, delete, filter, or MongoDB
+  operations.
+- Documented the persistent-state boundary and added ordering-sensitive source,
+  test, current-document, and completed-plan contracts.
 
 ## Verification Completed
 
-Pending implementation and validation.
+- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_sample_stream.py`
+- `make lint`, `make test`, `make build`, and `make check`
+- Ran the baseline checker from an external working directory.
+- Parsed the workflow YAML and dependency manifests.
+- Confirmed focused hostile mutations to failure ordering, test assertions,
+  current documentation, and completed-plan evidence are rejected.
+- `git diff --check`
+- The intended-path secret and generated-artifact scan passed; credentials,
+  dependency locks, configuration, storage fields, rule expressions, dry-run
+  behavior, and rate-limit handling had no unrelated diff.

--- a/docs/plans/2026-06-13-stream-rule-list-error-boundary.md
+++ b/docs/plans/2026-06-13-stream-rule-list-error-boundary.md
@@ -1,0 +1,33 @@
+# Stream Rule List Error Boundary
+
+status: pending
+
+## Context
+
+The worker lists persistent API v2 rules before replacing its tagged rule, but
+currently treats a failed list response like an empty rule set. That can add
+project-wide persistent state without knowing whether an older worker-owned
+rule already exists.
+
+## Requirements
+
+- Abort synchronization when Twitter/X reports errors while listing rules.
+- Perform no add, delete, filter, or MongoDB write after a failed list response.
+- Preserve the existing add-before-delete ordering once listing succeeds so a
+  rejected replacement still leaves the prior worker-owned rule intact.
+- Add no-network regression coverage and mutation-sensitive static contracts.
+- Document the operator-visible failure boundary and residual live-API risk.
+
+## Scope Boundaries
+
+- Do not change rule expressions, tags, credentials, dependencies, storage,
+  rate-limit handling, or dry-run behavior.
+- Do not add retries or suppress Twitter/X response errors.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and validation.

--- a/sample_stream.py
+++ b/sample_stream.py
@@ -78,7 +78,10 @@ def tagged_rule_ids(rules):
 
 
 def sync_stream_rule(stream, rule_value):
-    current = stream.get_rules().data or []
+    listed_rules = stream.get_rules()
+    if listed_rules.errors:
+        raise RuntimeError("Twitter/X could not list existing stream rules")
+    current = listed_rules.data or []
     existing_ids = tagged_rule_ids(current)
     result = stream.add_rules(tweepy.StreamRule(value=rule_value, tag=RULE_TAG))
     if result.errors or not result.data:

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -16,6 +16,7 @@ RATE_LIMIT_DISCONNECT_PLAN = "docs/plans/2026-06-12-stream-rate-limit-disconnect
 MODERN_DEPENDENCIES_PLAN = "docs/plans/2026-06-12-modern-stream-dependencies.md"
 HASH_LOCK_PLAN = "docs/plans/2026-06-12-hash-locked-dependency-installs.md"
 DRY_RUN_PLAN = "docs/plans/2026-06-13-dry-run-stream-rule.md"
+RULE_LIST_ERROR_PLAN = "docs/plans/2026-06-13-stream-rule-list-error-boundary.md"
 PRODUCTION_LOCK_SHA256 = "27ea76d7d0f7efea504ebcee475e411502bc775dceab3e10501563085d77ce1c"
 AUDIT_LOCK_SHA256 = "fc7ce7c6f13eee2008ea150facb1560903d6d12f4d6ad5245e68fdc3a75e607b"
 REQUIRED = [
@@ -46,6 +47,7 @@ REQUIRED = [
     MODERN_DEPENDENCIES_PLAN,
     HASH_LOCK_PLAN,
     DRY_RUN_PLAN,
+    RULE_LIST_ERROR_PLAN,
     "requirements-audit.in",
     "requirements-audit.lock",
     "requirements.txt",
@@ -146,6 +148,8 @@ def main():
         "if status_code in (420, 429)",
         "self.disconnect()",
         "tweepy.StreamRule(value=rule_value, tag=RULE_TAG)",
+        "if listed_rules.errors:",
+        "Twitter/X could not list existing stream rules",
         "stream.delete_rules(existing_ids)",
         "if result.errors or not result.data",
         "Twitter/X rejected the replacement stream rule",
@@ -171,6 +175,20 @@ def main():
     for retired in ["OAuthHandler", "StreamListener", "tweepy.streaming.Stream", ".tweets.insert("]:
         if retired in stream:
             failures.append(f"sample_stream.py must not restore retired API {retired}")
+    sync_source = stream[stream.find("def sync_stream_rule"):stream.find("def expanded_username")]
+    sync_markers = [
+        "listed_rules = stream.get_rules()",
+        "if listed_rules.errors:",
+        "stream.add_rules(",
+        "stream.delete_rules(existing_ids)",
+    ]
+    if any(marker not in sync_source for marker in sync_markers) or not all(
+        sync_source.find(left) < sync_source.find(right)
+        for left, right in zip(sync_markers, sync_markers[1:])
+    ):
+        failures.append(
+            "rule synchronization must reject list errors before add and delete operations"
+        )
 
     tests = read("test_sample_stream.py")
     for phrase in [
@@ -181,6 +199,10 @@ def main():
         "test_start_stream_configures_tagged_oscars_rule",
         "test_start_stream_replaces_only_worker_tagged_rules",
         "test_rejected_replacement_rule_preserves_existing_rule",
+        "test_rule_list_error_aborts_before_remote_mutation",
+        "FakeStreamingClient.get_errors",
+        "self.assertEqual([], stream.rule_operations)",
+        "self.assertIsNone(stream.filter_options)",
         "test_rule_terms_are_literal_and_bounded",
         "test_start_stream_accepts_single_custom_track_term",
         "test_start_stream_rejects_invalid_track_terms_before_client_setup",
@@ -199,6 +221,16 @@ def main():
     ]:
         if phrase not in tests:
             failures.append(f"test_sample_stream.py must include {phrase}")
+
+    rule_error_docs = {
+        "README.md": "startup stops before adding, deleting, or filtering",
+        "SECURITY.md": "failed existing-rule query aborts startup before add, delete, or filter",
+        "VISION.md": "failed persistent-rule discovery ahead of add, delete, and filter calls",
+        "CHANGES.md": "Abort stream startup before remote mutation",
+    }
+    for path, phrase in rule_error_docs.items():
+        if phrase not in " ".join(read(path).split()):
+            failures.append(f"{path} must include {phrase}")
 
     makefile = read("Makefile")
     for phrase in [
@@ -468,6 +500,38 @@ def main():
     ]:
         if evidence not in dry_run_verification:
             failures.append(f"dry-run verification must record {evidence}")
+
+    rule_list_error_plan = read(RULE_LIST_ERROR_PLAN)
+    rule_list_error_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", rule_list_error_plan
+    )
+    rule_list_error_work = markdown_section(rule_list_error_plan, "Work Completed")
+    rule_list_error_verification = markdown_section(
+        rule_list_error_plan, "Verification Completed"
+    )
+    if rule_list_error_status != ["completed"] or not rule_list_error_work:
+        failures.append(
+            "rule-list error plan must record one completed status and completed work"
+        )
+    if not rule_list_error_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run)\b", rule_list_error_verification
+    ):
+        failures.append("rule-list error plan must record completed verification")
+    for evidence in [
+        "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_sample_stream.py",
+        "make lint",
+        "make test",
+        "make build",
+        "make check",
+        "external working directory",
+        "workflow YAML",
+        "dependency manifests",
+        "hostile mutations",
+        "git diff --check",
+        "secret and generated-artifact scan",
+    ]:
+        if evidence not in rule_list_error_verification:
+            failures.append(f"rule-list error verification must record {evidence}")
 
     try:
         ET.parse(ROOT / "docs/readme-overview.svg")

--- a/test_sample_stream.py
+++ b/test_sample_stream.py
@@ -17,7 +17,9 @@ class FakeStreamRule:
 
 class FakeStreamingClient:
     initial_rules = []
+    get_errors = None
     add_errors = None
+    instances = []
 
     def __init__(self, bearer_token, **options):
         self.bearer_token = bearer_token
@@ -28,9 +30,13 @@ class FakeStreamingClient:
         self.disconnected = False
         self.rules = list(self.initial_rules)
         self.rule_operations = []
+        self.instances.append(self)
 
     def get_rules(self):
-        return types.SimpleNamespace(data=self.rules)
+        return types.SimpleNamespace(
+            data=None if self.get_errors else self.rules,
+            errors=self.get_errors,
+        )
 
     def delete_rules(self, ids):
         self.deleted_rule_ids.extend(ids)
@@ -87,7 +93,9 @@ def load_sample_stream(overrides=None, rules=None):
         os.environ[key] = value
 
     FakeStreamingClient.initial_rules = list(rules or [])
+    FakeStreamingClient.get_errors = None
     FakeStreamingClient.add_errors = None
+    FakeStreamingClient.instances = []
     sys.modules["tweepy"] = types.SimpleNamespace(
         StreamingClient=FakeStreamingClient,
         StreamRule=FakeStreamRule,
@@ -216,6 +224,20 @@ class SampleStreamTest(unittest.TestCase):
             sample_stream.sync_stream_rule(stream, "#oscars")
         self.assertEqual([], stream.deleted_rule_ids)
         self.assertEqual(["add"], stream.rule_operations)
+
+    def test_rule_list_error_aborts_before_remote_mutation(self):
+        sample_stream = load_sample_stream()
+        FakeStreamingClient.get_errors = [{"message": "authorization failed"}]
+
+        with self.assertRaisesRegex(RuntimeError, "could not list existing"):
+            sample_stream.start_stream()
+
+        stream = FakeStreamingClient.instances[-1]
+        self.assertEqual([], stream.rule_operations)
+        self.assertEqual([], stream.added_rules)
+        self.assertEqual([], stream.deleted_rule_ids)
+        self.assertIsNone(stream.filter_options)
+        self.assertEqual([], stream.db.tweets.documents)
 
     def test_rule_terms_are_literal_and_bounded(self):
         sample_stream = load_sample_stream()


### PR DESCRIPTION
## Summary

Stop live stream startup when Twitter/X reports an error while listing persistent API v2 rules.

## Baseline

The worker previously treated a failed list response as an empty rule set, allowing it to add project-wide persistent state without knowing which worker-owned rules already existed.

## Improvements

- reject list-response errors before tagged-rule selection, add, delete, or filter calls
- preserve the existing add-before-delete ordering after successful discovery
- add a no-network startup regression test plus mutation-sensitive source, documentation, and completed-plan contracts

## Validation

- 17 no-network unit tests
- `make lint`, `make test`, `make build`, and `make check`
- external-working-directory checker, Python compile, workflow YAML parse, and hash-locked manifest dry runs
- eight hostile mutations rejected
- exact diff, generated-artifact, and secret scans

## Risk

Live Twitter/X response behavior remains credential-dependent and is not exercised locally. The change does not add retries or alter rule expressions, storage, dependencies, dry-run behavior, or rate-limit handling.

## Follow-Ups

This PR is stacked on #8 and targets `lfg/oscars-dry-run-stream-rule-20260613`. It remains open for repository-owner review and must not be merged or closed automatically.
