### PR TITLE
fix: make Python gates location-independent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-14
+
+- Made every standard Make gate resolve unittest discovery and checker paths
+  from the repository root, including external absolute-Makefile calls.
+
 ## 2026-06-13
 
 - Abort stream startup before remote mutation when Twitter/X cannot list the

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: build check lint static-check test verify
 
 PYTHON ?= python3
+override REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 check: test lint
 
@@ -11,7 +12,7 @@ build: static-check
 lint: static-check
 
 test:
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m unittest discover -v
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m unittest discover -v -s "$(REPO_ROOT)"
 
 static-check:
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) scripts/check-baseline.py
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) "$(REPO_ROOT)/scripts/check-baseline.py"

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Run `make check`, `make lint`, `make build`, and `make verify` before
   changing stream startup, credential handling, MongoDB writes, or the
   `#oscars` filter.
+- Standard Make aliases resolve unittest discovery and checker paths from
+  `Makefile`, so an absolute Makefile path works from another directory.
 - See `CHANGES.md` and `docs/plans/2026-06-08-oscars-stream-baseline.md` for
   the current worker baseline.
 - See `docs/plans/2026-06-10-hosted-no-network-validation.md` for the hosted

--- a/docs/plans/2026-06-14-location-independent-make-gates.md
+++ b/docs/plans/2026-06-14-location-independent-make-gates.md
@@ -1,0 +1,47 @@
+# Location-Independent Make Gates
+
+status: planned
+
+## Context
+
+The standard Make aliases pass from the repository root, but an absolute
+Makefile invocation from another directory resolves unittest discovery and
+`scripts/check-baseline.py` against the caller. Shared automation should run
+the same no-network suite and static contracts without first changing its own
+working directory.
+
+## Requirements
+
+- Derive an override-protected repository root from the Makefile location.
+- Run unittest discovery from that repository root without changing test
+  selection, verbosity, Python override behavior, or bytecode suppression.
+- Invoke the static checker by its rooted path.
+- Preserve the current alias graph, no-network behavior, dependency manifests,
+  runtime code, and hosted Python 3.10/3.12 plus audit coverage.
+- Statically reject caller-relative or caller-overridable gate execution.
+- Record completed repository-root and external-working-directory evidence.
+
+## Scope Boundaries
+
+- Do not change Twitter/X rule behavior, MongoDB persistence, configuration,
+  credentials, dependencies, lock files, tests, or workflow jobs.
+- Do not add live API calls, network-dependent validation, or secret fixtures.
+- Do not weaken the baseline checker or no-network unittest suite.
+
+## Implementation Units
+
+1. Root unittest and checker execution at the Makefile's repository while
+   preserving every existing alias and command option.
+2. Extend `scripts/check-baseline.py` to require the rooted recipes, this plan,
+   completed evidence, and maintenance documentation.
+3. Document the external invocation contract in `README.md` and `CHANGES.md`.
+
+## Verification Plan
+
+- Run all standard aliases from the repository root and through the absolute
+  Makefile path from `/tmp`.
+- Confirm a caller-supplied repository-root variable cannot redirect commands.
+- Compile the checker outside the repository, parse workflow YAML, and run the
+  existing hash-locked dependency manifest dry runs.
+- Run isolated hostile mutations over rooted execution and completion evidence.
+- Audit intended paths, whitespace, generated artifacts, and secret-like data.

--- a/docs/plans/2026-06-14-location-independent-make-gates.md
+++ b/docs/plans/2026-06-14-location-independent-make-gates.md
@@ -1,6 +1,6 @@
 # Location-Independent Make Gates
 
-status: planned
+status: completed
 
 ## Context
 
@@ -45,3 +45,30 @@ working directory.
   existing hash-locked dependency manifest dry runs.
 - Run isolated hostile mutations over rooted execution and completion evidence.
 - Audit intended paths, whitespace, generated artifacts, and secret-like data.
+
+## Work Completed
+
+The Makefile now derives an override-protected absolute repository root from
+its own location. Unittest discovery receives that root as its explicit start
+directory, and the dependency-free checker is invoked by its rooted path.
+Existing aliases, Python overrides, bytecode suppression, tests, runtime code,
+and dependency manifests remain unchanged.
+
+## Verification Completed
+
+- `make lint`, `make test`, `make build`, `make verify`, `make check`, and
+  `make static-check` passed from the repository root; the test-bearing aliases
+  ran all 17 no-network tests.
+- Every alias passed from `/tmp` through the repository's absolute Makefile
+  path.
+- External `make check` passed with caller-supplied `REPO_ROOT=/tmp`, confirming
+  command-line variables cannot redirect discovery or checker execution.
+- External `make check` passed with a caller-relative `PYTHON=./oscars-python`
+  override, confirming rooted discovery does not reinterpret the interpreter.
+- Hash-required pip dry runs passed for `requirements.lock` and
+  `requirements-audit.lock` without changing either manifest.
+- `python3 -m py_compile scripts/check-baseline.py` passed with bytecode routed
+  outside the repository, and the pinned workflow YAML parsed successfully.
+- Ten isolated hostile mutations were rejected across root derivation,
+  override resistance, unittest and checker recipes, completed evidence, and
+  maintenance documentation.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -17,6 +17,7 @@ MODERN_DEPENDENCIES_PLAN = "docs/plans/2026-06-12-modern-stream-dependencies.md"
 HASH_LOCK_PLAN = "docs/plans/2026-06-12-hash-locked-dependency-installs.md"
 DRY_RUN_PLAN = "docs/plans/2026-06-13-dry-run-stream-rule.md"
 RULE_LIST_ERROR_PLAN = "docs/plans/2026-06-13-stream-rule-list-error-boundary.md"
+LOCATION_INDEPENDENT_MAKE_PLAN = "docs/plans/2026-06-14-location-independent-make-gates.md"
 PRODUCTION_LOCK_SHA256 = "27ea76d7d0f7efea504ebcee475e411502bc775dceab3e10501563085d77ce1c"
 AUDIT_LOCK_SHA256 = "fc7ce7c6f13eee2008ea150facb1560903d6d12f4d6ad5245e68fdc3a75e607b"
 REQUIRED = [
@@ -48,6 +49,7 @@ REQUIRED = [
     HASH_LOCK_PLAN,
     DRY_RUN_PLAN,
     RULE_LIST_ERROR_PLAN,
+    LOCATION_INDEPENDENT_MAKE_PLAN,
     "requirements-audit.in",
     "requirements-audit.lock",
     "requirements.txt",
@@ -231,12 +233,18 @@ def main():
     for path, phrase in rule_error_docs.items():
         if phrase not in " ".join(read(path).split()):
             failures.append(f"{path} must include {phrase}")
+    changes = " ".join(read("CHANGES.md").split())
+    if "external absolute-Makefile calls" not in changes:
+        failures.append(
+            "CHANGES.md must record external absolute-Makefile calls"
+        )
 
     makefile = read("Makefile")
     for phrase in [
         "PYTHON ?= python3",
-        "PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m unittest discover -v",
-        "PYTHONDONTWRITEBYTECODE=1 $(PYTHON) scripts/check-baseline.py",
+        "override REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))",
+        'PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m unittest discover -v -s "$(REPO_ROOT)"',
+        'PYTHONDONTWRITEBYTECODE=1 $(PYTHON) "$(REPO_ROOT)/scripts/check-baseline.py"',
         "lint: static-check",
         "build: static-check",
         "verify: check",
@@ -362,6 +370,7 @@ def main():
         "credential-free dry-run output",
         "stable JSON",
         "does not prove",
+        "absolute Makefile path works from another directory",
     ]:
         if phrase.lower() not in docs.lower():
             failures.append(f"docs must mention {phrase}")
@@ -532,6 +541,48 @@ def main():
     ]:
         if evidence not in rule_list_error_verification:
             failures.append(f"rule-list error verification must record {evidence}")
+
+    location_make_plan = read(LOCATION_INDEPENDENT_MAKE_PLAN)
+    location_make_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", location_make_plan
+    )
+    location_make_work = markdown_section(location_make_plan, "Work Completed")
+    location_make_verification = markdown_section(
+        location_make_plan, "Verification Completed"
+    )
+    if location_make_status != ["completed"] or not location_make_work:
+        failures.append(
+            "location-independent Make plan must record one completed status "
+            "and completed work"
+        )
+    if not location_make_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run)\b", location_make_verification
+    ):
+        failures.append(
+            "location-independent Make plan must record completed verification"
+        )
+    for evidence in [
+        "make lint",
+        "make test",
+        "make build",
+        "make verify",
+        "make check",
+        "make static-check",
+        "17 no-network tests",
+        "from `/tmp`",
+        "absolute",
+        "caller-supplied `REPO_ROOT=/tmp`",
+        "caller-relative `PYTHON=./oscars-python`",
+        "requirements.lock",
+        "requirements-audit.lock",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "workflow YAML parsed successfully",
+        "Ten isolated hostile mutations were rejected",
+    ]:
+        if evidence not in location_make_verification:
+            failures.append(
+                f"location-independent Make verification must record {evidence}"
+            )
 
     try:
         ET.parse(ROOT / "docs/readme-overview.svg")


### PR DESCRIPTION
## Summary

The Oscars stream’s complete Make gate can now run through an absolute Makefile path from any working directory. Previously, external callers discovered tests and the checker relative to themselves; the Makefile now supplies an override-protected repository root while preserving caller-selected Python interpreters.

## Baseline

- Repository-root aliases passed, but external static checking failed before the checker started.
- Unittest discovery from an external directory would inspect the wrong tree.

## Improvements

- Give unittest discovery an explicit repository start directory without changing `PYTHON` override semantics.
- Invoke the static checker through its absolute repository path.
- Statically enforce rooted execution, completed evidence, and maintenance documentation.

## Validation

- All six aliases passed from the repository root and `/tmp`; test-bearing aliases ran all 17 no-network tests.
- External `make check` passed with both `REPO_ROOT=/tmp` and caller-relative `PYTHON=./oscars-python` overrides.
- Hash-required pip dry runs passed for both production and audit locks.
- Python syntax compilation and pinned workflow YAML parsing passed.
- Ten isolated hostile mutations were rejected.
- The exact five-file implementation diff passed whitespace, generated-artifact, intended-path, and secret-pattern audits.

## Risk

Low. Runtime code, Twitter/X behavior, MongoDB behavior, tests, dependencies, lock files, and hosted Python/audit jobs are unchanged. The default branch’s existing two moderate Dependabot alerts are not introduced by this diff; the stacked remediated lock remains unchanged.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this change only affects maintenance command path resolution. The canonical Python 3.10, Python 3.12, and dependency-audit jobs should remain successful on push and pull-request events; any failed job is the rollback trigger.

## Follow-Ups

- This PR is stacked on the open rule-list error-boundary PR and should remain unmerged until its base is reviewed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/GPT--5-000000)
