### PR TITLE
fix: stop filtering after rule deletion failures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-15
+
+- Stop stream startup before filtering when Twitter/X rejects deletion of the
+  previous worker-tagged rules.
+
 ## 2026-06-14
 
 - Made every standard Make gate resolve unittest discovery and checker paths

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ python -m pip_audit --require-hashes --no-deps -r requirements.lock
   API v2 rules tagged `oscars-sample-stream`; unrelated project rules are not
   deleted. If the existing-rule query fails, startup stops before adding,
   deleting, or filtering so project-wide rule state is not changed blindly.
+  After a replacement is added, a rejected stale-rule deletion stops startup
+  before filtering so partial remote synchronization is visible to operators.
 - Custom stream filters must contain at least one non-empty string after
   trimming; blank custom stream filters are rejected instead of silently using
   the default.
@@ -150,6 +152,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Explicit MongoDB client injection should stay reliable for fake clients used
   in no-network tests.
 - Tagged API v2 rule replacement must never delete another worker's rules.
+- Failed tagged-rule deletion must not be treated as successful synchronization
+  or allow filter startup to continue.
 - Stream payloads without a matching expanded author must not be stored.
 
 ## Maintenance Notes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,7 +66,9 @@ Persistent API v2 rules are project-wide state. The worker may replace only
 rules tagged `oscars-sample-stream`; broad deletion could disrupt unrelated
 stream consumers. Rule expressions are bounded to 512 UTF-8 bytes before
 client setup. A failed existing-rule query aborts startup before add, delete,
-or filter operations rather than treating unknown project state as empty.
+or filter operations rather than treating unknown project state as empty. A
+failed tagged-rule deletion stops startup before filtering rather than hiding
+partially synchronized remote rule state.
 Use `python sample_stream.py --dry-run` to inspect normalized rule JSON without
 reading bearer-token or MongoDB environment values, constructing clients,
 mutating persistent API v2 rules, starting a stream, or writing documents.

--- a/VISION.md
+++ b/VISION.md
@@ -41,6 +41,7 @@ Priority:
 - Keep API v2 stream rate-limit errors from reconnecting indefinitely
 - Keep rule replacement scoped to the `oscars-sample-stream` tag
 - Keep failed persistent-rule discovery ahead of add, delete, and filter calls
+- Keep failed tagged-rule deletion visible before filter startup
 - Require expanded author identity before MongoDB storage through `insert_one`
 - Keep verification targets from leaving Python bytecode behind
 - Keep Python 3.10 and 3.12 hosted Linux validation credential-free and

--- a/docs/plans/2026-06-15-stream-rule-delete-error-boundary.md
+++ b/docs/plans/2026-06-15-stream-rule-delete-error-boundary.md
@@ -1,6 +1,6 @@
 # Stream Rule Delete Error Boundary
 
-status: planned
+status: completed
 
 ## Context
 
@@ -50,12 +50,34 @@ though both the replacement rule and stale worker rules can remain active.
   starts filtering or writes a tweet.
 - Listing and replacement-add failures retain their existing behavior.
 
-## Verification To Complete
+## Work Completed
 
-- Run the focused deletion-error regression and full no-network unit suite.
-- Run `make check` from the repository root and through the absolute Makefile
-  path from an external directory.
-- Audit both exact dependency locks.
-- Reject isolated hostile mutations for response checking, test/static
-  contracts, documentation, and completed plan evidence.
-- Run final diff, artifact, and likely-secret audits before committing.
+- Captured the structured `delete_rules` response and raised a stable runtime
+  error when Twitter/X reports deletion errors.
+- Preserved add-before-delete ordering while preventing filter startup after a
+  partially synchronized remote rule update.
+- Extended the fake client with configurable delete errors and added a focused
+  regression proving add and delete were attempted without filtering or
+  persistence.
+- Added mutation-sensitive static contracts and updated maintenance, security,
+  vision, and change documentation for the deletion-error boundary.
+
+## Verification Completed
+
+- four focused rule synchronization tests passed for successful replacement,
+  replacement rejection, rule-list rejection, and delete rejection.
+- The full suite passed all 18 no-network tests with the exact hash-locked
+  production runtime on Python 3.12.
+- `make check` passed from the repository root and through the absolute
+  Makefile path from an external working directory in an exact mirror before
+  this evidence update, then passed again on the actual worktree.
+- `requirements.lock` installed with hashes and passed `pip check` after
+  removing the workstation's unrelated `PYTHONPATH` injection.
+- `requirements-audit.lock` installed with hashes and passed `pip check`; its
+  pinned `pip-audit` reported no known vulnerabilities in `requirements.lock`.
+- Seven isolated hostile mutations were rejected: removed response checking,
+  removed response capture, removed test naming contract, removed fake error
+  contract, removed documentation, incomplete plan status, and a runtime
+  response-check bypass caught by the focused regression.
+- `git diff --check`, exact intended-path review, and the final high-signal
+  secret and generated-artifact scan passed.

--- a/docs/plans/2026-06-15-stream-rule-delete-error-boundary.md
+++ b/docs/plans/2026-06-15-stream-rule-delete-error-boundary.md
@@ -1,0 +1,61 @@
+# Stream Rule Delete Error Boundary
+
+status: planned
+
+## Context
+
+`sync_stream_rule` checks failures while listing and adding Twitter/X filtered
+stream rules, but discards the response from deleting the previous tagged
+rules. Tweepy 4.16 returns a structured mutation response from `delete_rules`.
+If that response contains errors, startup currently proceeds to filtering even
+though both the replacement rule and stale worker rules can remain active.
+
+## Objectives
+
+- Treat a rejected deletion of existing worker-tagged rules as a failed rule
+  synchronization.
+- Prevent `filter` startup after a deletion error.
+- Preserve the current add-before-delete ordering so a rejected replacement
+  does not remove the last known worker rule.
+- Add no-network regression coverage and a mutation-sensitive static contract.
+- Record completed focused, full-suite, external-directory, dependency, and
+  artifact/secret verification.
+
+## Scope Boundaries
+
+- Do not change rule matching, tags, dry-run output, credentials, MongoDB
+  persistence, or rate-limit handling.
+- Do not make live Twitter/X or MongoDB calls in tests.
+- Do not attempt automatic rollback of a successfully added replacement when
+  the remote deletion request fails; surface the partial synchronization so an
+  operator can retry or inspect remote rule state.
+- Keep this change stacked on the location-independent Make pull request.
+
+## Implementation Units
+
+1. Extend the fake streaming client with a structured delete response and a
+   configurable deletion error.
+2. Capture the production deletion response and raise a stable runtime error
+   when Twitter/X rejects deletion of existing tagged rules.
+3. Prove the failure occurs after replacement creation but before `filter`
+   startup or tweet persistence.
+4. Extend the static checker, README, security guidance, changelog, and this
+   plan's completed evidence so the boundary cannot silently regress.
+
+## Test Scenarios
+
+- A successful rule replacement still performs add, delete, then filter.
+- A deletion response with errors raises a stable runtime error.
+- The failed deletion path records the attempted add and delete but never
+  starts filtering or writes a tweet.
+- Listing and replacement-add failures retain their existing behavior.
+
+## Verification To Complete
+
+- Run the focused deletion-error regression and full no-network unit suite.
+- Run `make check` from the repository root and through the absolute Makefile
+  path from an external directory.
+- Audit both exact dependency locks.
+- Reject isolated hostile mutations for response checking, test/static
+  contracts, documentation, and completed plan evidence.
+- Run final diff, artifact, and likely-secret audits before committing.

--- a/sample_stream.py
+++ b/sample_stream.py
@@ -87,7 +87,9 @@ def sync_stream_rule(stream, rule_value):
     if result.errors or not result.data:
         raise RuntimeError("Twitter/X rejected the replacement stream rule")
     if existing_ids:
-        stream.delete_rules(existing_ids)
+        delete_result = stream.delete_rules(existing_ids)
+        if delete_result.errors:
+            raise RuntimeError("Twitter/X could not delete existing stream rules")
 
 
 def expanded_username(payload, author_id):

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -18,6 +18,7 @@ HASH_LOCK_PLAN = "docs/plans/2026-06-12-hash-locked-dependency-installs.md"
 DRY_RUN_PLAN = "docs/plans/2026-06-13-dry-run-stream-rule.md"
 RULE_LIST_ERROR_PLAN = "docs/plans/2026-06-13-stream-rule-list-error-boundary.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = "docs/plans/2026-06-14-location-independent-make-gates.md"
+RULE_DELETE_ERROR_PLAN = "docs/plans/2026-06-15-stream-rule-delete-error-boundary.md"
 PRODUCTION_LOCK_SHA256 = "27ea76d7d0f7efea504ebcee475e411502bc775dceab3e10501563085d77ce1c"
 AUDIT_LOCK_SHA256 = "fc7ce7c6f13eee2008ea150facb1560903d6d12f4d6ad5245e68fdc3a75e607b"
 REQUIRED = [
@@ -50,6 +51,7 @@ REQUIRED = [
     DRY_RUN_PLAN,
     RULE_LIST_ERROR_PLAN,
     LOCATION_INDEPENDENT_MAKE_PLAN,
+    RULE_DELETE_ERROR_PLAN,
     "requirements-audit.in",
     "requirements-audit.lock",
     "requirements.txt",
@@ -182,14 +184,16 @@ def main():
         "listed_rules = stream.get_rules()",
         "if listed_rules.errors:",
         "stream.add_rules(",
-        "stream.delete_rules(existing_ids)",
+        "delete_result = stream.delete_rules(existing_ids)",
+        "if delete_result.errors:",
     ]
     if any(marker not in sync_source for marker in sync_markers) or not all(
         sync_source.find(left) < sync_source.find(right)
         for left, right in zip(sync_markers, sync_markers[1:])
     ):
         failures.append(
-            "rule synchronization must reject list errors before add and delete operations"
+            "rule synchronization must reject list errors before mutation and "
+            "delete errors before filter startup"
         )
 
     tests = read("test_sample_stream.py")
@@ -202,7 +206,10 @@ def main():
         "test_start_stream_replaces_only_worker_tagged_rules",
         "test_rejected_replacement_rule_preserves_existing_rule",
         "test_rule_list_error_aborts_before_remote_mutation",
+        "test_rule_delete_error_aborts_before_filter_start",
         "FakeStreamingClient.get_errors",
+        "FakeStreamingClient.delete_errors",
+        "self.assertEqual([\"add\", \"delete\"], stream.rule_operations)",
         "self.assertEqual([], stream.rule_operations)",
         "self.assertIsNone(stream.filter_options)",
         "test_rule_terms_are_literal_and_bounded",
@@ -231,6 +238,16 @@ def main():
         "CHANGES.md": "Abort stream startup before remote mutation",
     }
     for path, phrase in rule_error_docs.items():
+        if phrase not in " ".join(read(path).split()):
+            failures.append(f"{path} must include {phrase}")
+
+    delete_error_docs = {
+        "README.md": "a rejected stale-rule deletion stops startup before filtering",
+        "SECURITY.md": "failed tagged-rule deletion stops startup before filtering",
+        "VISION.md": "failed tagged-rule deletion visible before filter startup",
+        "CHANGES.md": "Stop stream startup before filtering when Twitter/X rejects deletion",
+    }
+    for path, phrase in delete_error_docs.items():
         if phrase not in " ".join(read(path).split()):
             failures.append(f"{path} must include {phrase}")
     changes = " ".join(read("CHANGES.md").split())
@@ -583,6 +600,39 @@ def main():
             failures.append(
                 f"location-independent Make verification must record {evidence}"
             )
+
+    rule_delete_error_plan = read(RULE_DELETE_ERROR_PLAN)
+    rule_delete_error_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", rule_delete_error_plan
+    )
+    rule_delete_error_work = markdown_section(
+        rule_delete_error_plan, "Work Completed"
+    )
+    rule_delete_error_verification = markdown_section(
+        rule_delete_error_plan, "Verification Completed"
+    )
+    if rule_delete_error_status != ["completed"] or not rule_delete_error_work:
+        failures.append(
+            "rule-delete error plan must record one completed status and completed work"
+        )
+    if not rule_delete_error_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run|to complete)\b",
+        rule_delete_error_verification,
+    ):
+        failures.append("rule-delete error plan must record completed verification")
+    for evidence in [
+        "four focused rule synchronization tests",
+        "18 no-network tests",
+        "make check",
+        "external working directory",
+        "requirements.lock",
+        "requirements-audit.lock",
+        "isolated hostile mutations",
+        "git diff --check",
+        "secret and generated-artifact scan",
+    ]:
+        if evidence not in rule_delete_error_verification:
+            failures.append(f"rule-delete error verification must record {evidence}")
 
     try:
         ET.parse(ROOT / "docs/readme-overview.svg")

--- a/test_sample_stream.py
+++ b/test_sample_stream.py
@@ -19,6 +19,7 @@ class FakeStreamingClient:
     initial_rules = []
     get_errors = None
     add_errors = None
+    delete_errors = None
     instances = []
 
     def __init__(self, bearer_token, **options):
@@ -41,6 +42,10 @@ class FakeStreamingClient:
     def delete_rules(self, ids):
         self.deleted_rule_ids.extend(ids)
         self.rule_operations.append("delete")
+        return types.SimpleNamespace(
+            data=None if self.delete_errors else {"deleted": list(ids)},
+            errors=self.delete_errors,
+        )
 
     def add_rules(self, rules):
         self.added_rules.append(rules)
@@ -95,6 +100,7 @@ def load_sample_stream(overrides=None, rules=None):
     FakeStreamingClient.initial_rules = list(rules or [])
     FakeStreamingClient.get_errors = None
     FakeStreamingClient.add_errors = None
+    FakeStreamingClient.delete_errors = None
     FakeStreamingClient.instances = []
     sys.modules["tweepy"] = types.SimpleNamespace(
         StreamingClient=FakeStreamingClient,
@@ -236,6 +242,23 @@ class SampleStreamTest(unittest.TestCase):
         self.assertEqual([], stream.rule_operations)
         self.assertEqual([], stream.added_rules)
         self.assertEqual([], stream.deleted_rule_ids)
+        self.assertIsNone(stream.filter_options)
+        self.assertEqual([], stream.db.tweets.documents)
+
+    def test_rule_delete_error_aborts_before_filter_start(self):
+        worker_rule = FakeStreamRule(
+            value="#oscars2025", tag="oscars-sample-stream", id="worker-old"
+        )
+        sample_stream = load_sample_stream(rules=[worker_rule])
+        FakeStreamingClient.delete_errors = [{"message": "delete rejected"}]
+
+        with self.assertRaisesRegex(RuntimeError, "could not delete existing"):
+            sample_stream.start_stream()
+
+        stream = FakeStreamingClient.instances[-1]
+        self.assertEqual(["add", "delete"], stream.rule_operations)
+        self.assertEqual(["worker-old"], stream.deleted_rule_ids)
+        self.assertEqual(1, len(stream.added_rules))
         self.assertIsNone(stream.filter_options)
         self.assertEqual([], stream.db.tweets.documents)
 


### PR DESCRIPTION
## Summary

The worker now stops before starting the filtered stream when Twitter/X rejects deletion of the previous worker-tagged rules. Previously, it discarded the delete response and continued as though synchronization succeeded, which could leave both the new replacement and stale rules active.

The add-before-delete ordering remains unchanged, so a rejected replacement still preserves the last known worker rule. A deletion rejection now surfaces the partial remote state for operator review instead of silently beginning collection with an unintended rule set.

## Baseline

- Rule listing failures stopped before remote mutation.
- Replacement-add failures preserved existing rules.
- Deletion responses were ignored, and filtering continued after a rejected stale-rule deletion.

## Improvements

- Inspect the pinned Tweepy 4.16 deletion response and raise a stable synchronization error when it contains errors.
- Prove add and delete were attempted while filter startup and MongoDB persistence remain untouched.
- Keep the static baseline, security guidance, vision, changelog, and completed plan evidence aligned with the runtime boundary.

## Validation

- Four focused rule synchronization cases passed.
- All 18 no-network unit tests passed with the exact hash-locked Python 3.12 runtime.
- `make check` passed from the repository root and through the absolute Makefile path from `/tmp`.
- Both hash-locked environments passed `pip check`; `pip-audit` reported zero known vulnerabilities for `requirements.lock`.
- Seven isolated hostile mutations were rejected, including a runtime bypass caught by the focused regression.
- Final whitespace, intended-path, generated-artifact, and likely-secret audits passed.

## Risk

- A deletion failure can still leave a newly added replacement alongside stale remote rules; this PR deliberately surfaces that partial state rather than attempting an unproven rollback.
- Live Twitter/X authorization, persistent rule state, stream delivery, and MongoDB persistence remain outside local no-network validation.
- GitHub reports two moderate Dependabot alerts on the default branch until the authorized remediation stack is merged; the exact branch lock audits clean.
- This PR is stacked on PR #10 and must preserve base-first merge ordering.

## Follow-Ups

- Exercise the rule synchronization path in an isolated credentialed Twitter/X project before production use.
- Re-evaluate rollback semantics only with a documented remote-state recovery contract and live integration coverage.

## Post-Deploy Monitoring & Validation

- For the first credentialed startup after merge, inspect worker logs for `Twitter/X could not delete existing stream rules` and confirm no filter-start log follows that error.
- In the Twitter/X developer project, verify exactly one `oscars-sample-stream` rule remains after a healthy startup and that unrelated tagged rules are unchanged.
- Healthy signal: replacement add, stale-rule deletion, and stream filter startup complete once with no duplicate worker-tagged rules.
- Failure signal: the deletion error repeats, multiple worker-tagged rules remain, or collection begins with stale filters. Stop the worker and reconcile rules manually before retrying.
- Validation window and owner: repository maintainer during the first deployment or credentialed smoke run after the stack is merged.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
