### PR TITLE
Reuse matching stream rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ These instructions apply to the entire repository.
 - Validate track terms and the final rule byte length before client setup.
 - Manage only API v2 rules tagged `oscars-sample-stream`; never delete
   unrelated project rules.
+- Reuse a single matching tagged rule without add/delete calls; stale or
+  duplicate worker-tagged rules must still converge through replacement.
 - Require author expansion before storing a normalized username.
 - Use `insert_one` for MongoDB writes and preserve explicit falsy-client
   injection.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-16
+
+- Reused a single matching tagged stream rule without add/delete calls while
+  retaining replacement convergence for stale or duplicate tagged state.
+
 ## 2026-06-15
 
 - Stop stream startup before filtering when Twitter/X rejects deletion of the

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ python -m pip_audit --require-hashes --no-deps -r requirements.lock
   API v2 rules tagged `oscars-sample-stream`; unrelated project rules are not
   deleted. If the existing-rule query fails, startup stops before adding,
   deleting, or filtering so project-wide rule state is not changed blindly.
+  A single matching tagged rule is reused without add/delete calls; stale,
+  missing, or duplicate tagged state still follows the convergence path.
   After a replacement is added, a rejected stale-rule deletion stops startup
   before filtering so partial remote synchronization is visible to operators.
 - Custom stream filters must contain at least one non-empty string after

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,6 +69,8 @@ client setup. A failed existing-rule query aborts startup before add, delete,
 or filter operations rather than treating unknown project state as empty. A
 failed tagged-rule deletion stops startup before filtering rather than hiding
 partially synchronized remote rule state.
+A single matching tagged rule is reused without remote mutations, reducing
+avoidable API failure exposure while duplicate or stale state still converges.
 Use `python sample_stream.py --dry-run` to inspect normalized rule JSON without
 reading bearer-token or MongoDB environment values, constructing clients,
 mutating persistent API v2 rules, starting a stream, or writing documents.

--- a/VISION.md
+++ b/VISION.md
@@ -42,6 +42,8 @@ Priority:
 - Keep rule replacement scoped to the `oscars-sample-stream` tag
 - Keep failed persistent-rule discovery ahead of add, delete, and filter calls
 - Keep failed tagged-rule deletion visible before filter startup
+- Reuse a single matching tagged rule without remote mutation while converging
+  stale or duplicate worker-tagged state
 - Require expanded author identity before MongoDB storage through `insert_one`
 - Keep verification targets from leaving Python bytecode behind
 - Keep Python 3.10 and 3.12 hosted Linux validation credential-free and

--- a/docs/plans/2026-06-16-idempotent-stream-rule-sync.md
+++ b/docs/plans/2026-06-16-idempotent-stream-rule-sync.md
@@ -1,0 +1,56 @@
+---
+title: Idempotent Stream Rule Synchronization
+status: in_progress
+date: 2026-06-16
+---
+
+# Idempotent Stream Rule Synchronization
+
+## Problem
+
+`sync_stream_rule` always adds a replacement and deletes the existing tagged
+rules, even when remote state already contains exactly one
+`oscars-sample-stream` rule with the desired value. Healthy worker restarts
+therefore consume unnecessary remote mutations and can fail during avoidable
+add/delete calls.
+
+## Priority
+
+Make the steady-state startup path read-only. Rule mutation should occur only
+when tagged state is stale, missing, or duplicated.
+
+## Requirements
+
+1. Reuse remote state without add/delete calls when exactly one tagged rule has
+   the desired value.
+2. Preserve replacement and stale-rule deletion when the tagged value differs,
+   no tagged rule exists, or duplicate tagged rules require convergence.
+3. Continue ignoring unrelated tags and aborting on list, add, or delete errors
+   before filtering starts.
+4. Add focused runtime and mutation-sensitive static, guidance, changelog, and
+   completed-plan coverage.
+5. Keep validation no-network and do not change credentials, filtering options,
+   persistence, dependency locks, or API versions.
+
+## Implementation
+
+- Add a small exact-match predicate for tagged rules and short-circuit
+  synchronization only for the single-rule desired-state case.
+- Extend fake-stream tests with no-mutation reuse plus duplicate/mismatch
+  replacement preservation.
+- Register source, tests, maintained guidance, and completed evidence in the
+  baseline checker.
+
+## Verification Plan
+
+- Focused stream-rule tests and complete no-network unittest suite
+- Repository-root and external-directory `make check`
+- Isolated hostile mutations for match cardinality/value, replacement behavior,
+  tests, guidance, and plan completion
+- Exact diff, bytecode/artifact, whitespace, mode, and credential audits
+
+## Scope Boundaries
+
+- Do not call the live Twitter/X API or MongoDB.
+- Do not alter the replacement-before-delete ordering for nonmatching state.
+- Do not merge or close any stacked pull request.

--- a/docs/plans/2026-06-16-idempotent-stream-rule-sync.md
+++ b/docs/plans/2026-06-16-idempotent-stream-rule-sync.md
@@ -1,6 +1,6 @@
 ---
 title: Idempotent Stream Rule Synchronization
-status: in_progress
+status: completed
 date: 2026-06-16
 ---
 
@@ -54,3 +54,25 @@ when tagged state is stale, missing, or duplicated.
 - Do not call the live Twitter/X API or MongoDB.
 - Do not alter the replacement-before-delete ordering for nonmatching state.
 - Do not merge or close any stacked pull request.
+
+## Work Completed
+
+- Reused exactly one matching worker-tagged rule without remote mutations.
+- Preserved add-then-delete convergence for missing, stale, or duplicate tagged
+  state, including all existing list/add/delete error boundaries.
+- Added focused runtime, static, guidance, changelog, and completed-plan
+  contracts.
+
+## Verification Completed
+
+- All six focused rule synchronization tests passed.
+- The complete 20 no-network tests passed.
+- A finalized tracked-file mirror passed repository validation.
+- The external working directory make check passed before this plan was
+  completed.
+- Six isolated hostile mutations were rejected for cardinality, value matching,
+  short-circuiting, runtime coverage, guidance, and plan status.
+- Exact diff, bytecode/artifact, whitespace, file-mode, and added-line credential
+  audits passed before the canonical final gates.
+- Live Twitter/X API authorization, persistent rule state, stream delivery, and
+  MongoDB persistence were not exercised.

--- a/sample_stream.py
+++ b/sample_stream.py
@@ -82,7 +82,10 @@ def sync_stream_rule(stream, rule_value):
     if listed_rules.errors:
         raise RuntimeError("Twitter/X could not list existing stream rules")
     current = listed_rules.data or []
-    existing_ids = tagged_rule_ids(current)
+    worker_rules = [rule for rule in current if rule.tag == RULE_TAG]
+    if len(worker_rules) == 1 and worker_rules[0].value == rule_value:
+        return
+    existing_ids = tagged_rule_ids(worker_rules)
     result = stream.add_rules(tweepy.StreamRule(value=rule_value, tag=RULE_TAG))
     if result.errors or not result.data:
         raise RuntimeError("Twitter/X rejected the replacement stream rule")

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -19,6 +19,7 @@ DRY_RUN_PLAN = "docs/plans/2026-06-13-dry-run-stream-rule.md"
 RULE_LIST_ERROR_PLAN = "docs/plans/2026-06-13-stream-rule-list-error-boundary.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = "docs/plans/2026-06-14-location-independent-make-gates.md"
 RULE_DELETE_ERROR_PLAN = "docs/plans/2026-06-15-stream-rule-delete-error-boundary.md"
+IDEMPOTENT_RULE_SYNC_PLAN = "docs/plans/2026-06-16-idempotent-stream-rule-sync.md"
 PRODUCTION_LOCK_SHA256 = "27ea76d7d0f7efea504ebcee475e411502bc775dceab3e10501563085d77ce1c"
 AUDIT_LOCK_SHA256 = "fc7ce7c6f13eee2008ea150facb1560903d6d12f4d6ad5245e68fdc3a75e607b"
 REQUIRED = [
@@ -52,6 +53,7 @@ REQUIRED = [
     RULE_LIST_ERROR_PLAN,
     LOCATION_INDEPENDENT_MAKE_PLAN,
     RULE_DELETE_ERROR_PLAN,
+    IDEMPOTENT_RULE_SYNC_PLAN,
     "requirements-audit.in",
     "requirements-audit.lock",
     "requirements.txt",
@@ -183,6 +185,8 @@ def main():
     sync_markers = [
         "listed_rules = stream.get_rules()",
         "if listed_rules.errors:",
+        "worker_rules = [rule for rule in current if rule.tag == RULE_TAG]",
+        "if len(worker_rules) == 1 and worker_rules[0].value == rule_value:",
         "stream.add_rules(",
         "delete_result = stream.delete_rules(existing_ids)",
         "if delete_result.errors:",
@@ -204,6 +208,8 @@ def main():
         "test_config_ignores_blank_bearer_token_and_uses_fallback",
         "test_start_stream_configures_tagged_oscars_rule",
         "test_start_stream_replaces_only_worker_tagged_rules",
+        "test_start_stream_reuses_single_matching_worker_rule",
+        "test_start_stream_replaces_duplicate_matching_worker_rules",
         "test_rejected_replacement_rule_preserves_existing_rule",
         "test_rule_list_error_aborts_before_remote_mutation",
         "test_rule_delete_error_aborts_before_filter_start",
@@ -211,6 +217,7 @@ def main():
         "FakeStreamingClient.delete_errors",
         "self.assertEqual([\"add\", \"delete\"], stream.rule_operations)",
         "self.assertEqual([], stream.rule_operations)",
+        "self.assertEqual([\"first\", \"second\"], stream.deleted_rule_ids)",
         "self.assertIsNone(stream.filter_options)",
         "test_rule_terms_are_literal_and_bounded",
         "test_start_stream_accepts_single_custom_track_term",
@@ -388,6 +395,7 @@ def main():
         "stable JSON",
         "does not prove",
         "absolute Makefile path works from another directory",
+        "single matching tagged rule",
     ]:
         if phrase.lower() not in docs.lower():
             failures.append(f"docs must mention {phrase}")
@@ -633,6 +641,34 @@ def main():
     ]:
         if evidence not in rule_delete_error_verification:
             failures.append(f"rule-delete error verification must record {evidence}")
+
+    idempotent_rule_plan = read(IDEMPOTENT_RULE_SYNC_PLAN)
+    idempotent_rule_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", idempotent_rule_plan
+    )
+    idempotent_rule_work = markdown_section(idempotent_rule_plan, "Work Completed")
+    idempotent_rule_verification = markdown_section(
+        idempotent_rule_plan, "Verification Completed"
+    )
+    if idempotent_rule_status != ["completed"] or not idempotent_rule_work:
+        failures.append(
+            "idempotent rule plan must record one completed status and completed work"
+        )
+    if not idempotent_rule_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run|to complete)\b",
+        idempotent_rule_verification,
+    ):
+        failures.append("idempotent rule plan must record completed verification")
+    for evidence in [
+        "six focused rule synchronization tests",
+        "20 no-network tests",
+        "make check",
+        "external working directory",
+        "Six isolated hostile mutations were rejected",
+        "Exact diff",
+    ]:
+        if evidence not in idempotent_rule_verification:
+            failures.append(f"idempotent rule verification must record {evidence}")
 
     try:
         ET.parse(ROOT / "docs/readme-overview.svg")

--- a/test_sample_stream.py
+++ b/test_sample_stream.py
@@ -215,6 +215,38 @@ class SampleStreamTest(unittest.TestCase):
         self.assertEqual('#oscars2026 OR "best picture"', stream.added_rules[0].value)
         self.assertEqual(["add", "delete"], stream.rule_operations)
 
+    def test_start_stream_reuses_single_matching_worker_rule(self):
+        rules = [
+            FakeStreamRule(
+                value="#oscars", tag="oscars-sample-stream", id="worker-current"
+            ),
+            FakeStreamRule(value="#other", tag="another-worker", id="unrelated"),
+        ]
+        sample_stream = load_sample_stream(rules=rules)
+
+        stream = sample_stream.start_stream()
+
+        self.assertEqual([], stream.rule_operations)
+        self.assertEqual([], stream.added_rules)
+        self.assertEqual([], stream.deleted_rule_ids)
+        self.assertEqual(
+            {"expansions": ["author_id"], "user_fields": ["username"]},
+            stream.filter_options,
+        )
+
+    def test_start_stream_replaces_duplicate_matching_worker_rules(self):
+        rules = [
+            FakeStreamRule(value="#oscars", tag="oscars-sample-stream", id="first"),
+            FakeStreamRule(value="#oscars", tag="oscars-sample-stream", id="second"),
+        ]
+        sample_stream = load_sample_stream(rules=rules)
+
+        stream = sample_stream.start_stream()
+
+        self.assertEqual(["add", "delete"], stream.rule_operations)
+        self.assertEqual(["first", "second"], stream.deleted_rule_ids)
+        self.assertEqual("#oscars", stream.added_rules[0].value)
+
     def test_rejected_replacement_rule_preserves_existing_rule(self):
         rules = [FakeStreamRule(id="ours", tag="oscars-sample-stream")]
         sample_stream = load_sample_stream(rules=rules)


### PR DESCRIPTION
## Summary

- reuse exactly one matching `oscars-sample-stream` rule without remote mutations
- retain add-then-delete convergence for missing, stale, or duplicate tagged state
- preserve list, add, and delete failure boundaries before stream filtering

## Baseline

The stacked base safely scopes persistent rules by tag and aborts on list/add/delete failures. It still replaced an already-correct singleton rule on every worker restart, consuming avoidable Twitter/X API mutations.

## Improvements

- short-circuit only when tagged rule cardinality is exactly one and its value matches
- keep unrelated project rules untouched
- prove duplicate matching rules still converge through replacement
- add runtime, static, guidance, changelog, and completed-plan contracts

## Validation

- six focused synchronization tests passed
- complete 20-test no-network suite passed
- repository `make check` passed
- absolute Makefile `check` from `/tmp` passed
- six isolated hostile mutations rejected
- exact diff, bytecode/artifact, whitespace, mode, and credential audits passed
- structured review approved; artifact SHA-256: `8d10cc3314f51c16c70583dc30e998a0d9985ad664b96f0b161537da27a9fb6f`

## Risk

No dependency, credential, filter-option, persistence, or API-version changes are included. Live Twitter/X authorization, persistent remote rule state, stream delivery, and MongoDB persistence were not exercised.

## Follow-Ups

- observe one authorized restart with an already-current tagged rule and confirm no add/delete API calls
- retain operator inspection when a replacement succeeds but stale-rule deletion fails

## Stack

This PR is stacked on #11 (`lfg/oscars-rule-delete-error-boundary-20260615`) and adds plan commit `455c2ee` plus implementation commit `df8822c`.

## Post-Deploy Monitoring

- require both push and pull_request Python matrices to pass at this exact head
- confirm exact-branch CodeQL remains clear
- monitor Twitter/X rule mutation errors and verify steady-state restarts no longer issue add/delete calls
