### PR TITLE
fix: retain matching stream rule during cleanup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-17
+
+- Added matching stream rule cleanup that retains an existing desired rule while
+  removing stale or duplicate worker-tagged rules without another add.
+
 ## 2026-06-16
 
 - Reused a single matching tagged stream rule without add/delete calls while

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ python -m pip_audit --require-hashes --no-deps -r requirements.lock
   deleting, or filtering so project-wide rule state is not changed blindly.
   A single matching tagged rule is reused without add/delete calls; stale,
   missing, or duplicate tagged state still follows the convergence path.
+  Matching stream rule cleanup retains one desired rule and deletes only stale
+  or duplicate worker rules without consuming capacity for another add.
   After a replacement is added, a rejected stale-rule deletion stops startup
   before filtering so partial remote synchronization is visible to operators.
 - Custom stream filters must contain at least one non-empty string after

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,6 +71,8 @@ failed tagged-rule deletion stops startup before filtering rather than hiding
 partially synchronized remote rule state.
 A single matching tagged rule is reused without remote mutations, reducing
 avoidable API failure exposure while duplicate or stale state still converges.
+Matching stream rule cleanup retains an existing desired rule and removes only
+redundant worker-tagged rules, limiting quota use and retry amplification.
 Use `python sample_stream.py --dry-run` to inspect normalized rule JSON without
 reading bearer-token or MongoDB environment values, constructing clients,
 mutating persistent API v2 rules, starting a stream, or writing documents.

--- a/VISION.md
+++ b/VISION.md
@@ -44,6 +44,8 @@ Priority:
 - Keep failed tagged-rule deletion visible before filter startup
 - Reuse a single matching tagged rule without remote mutation while converging
   stale or duplicate worker-tagged state
+- Preserve matching stream rule cleanup so an existing desired rule is retained
+  while stale and duplicate worker rules are removed without another add
 - Require expanded author identity before MongoDB storage through `insert_one`
 - Keep verification targets from leaving Python bytecode behind
 - Keep Python 3.10 and 3.12 hosted Linux validation credential-free and

--- a/docs/plans/2026-06-17-matching-stream-rule-cleanup.md
+++ b/docs/plans/2026-06-17-matching-stream-rule-cleanup.md
@@ -1,6 +1,6 @@
 # Matching Stream Rule Cleanup
 
-status: planned
+status: completed
 
 ## Problem
 
@@ -68,6 +68,29 @@ guidance, and completed plan evidence against isolated hostile mutations.
 - Do not delete unrelated rules or switch the no-match replacement path to
   delete-first behavior.
 - Do not merge or close any stacked pull request.
+
+## Work Completed
+
+- Partitioned worker-tagged rules by desired value and retained the first
+  existing match during synchronization.
+- Deleted only stale or duplicate worker-tagged rule identifiers on the cleanup
+  path and returned before replacement creation.
+- Preserved add-first replacement when no desired rule exists, including the
+  existing list, add, deletion, filter-start, and unrelated-rule boundaries.
+- Added no-network regressions, static contracts, synchronized guidance, and
+  this completed evidence record.
+
+## Verification Completed
+
+- eight focused rule synchronization tests passed, including matching-plus-stale,
+  duplicate matching, cleanup deletion failure, and no-match replacement cases.
+- The complete suite passed with 22 no-network tests.
+- All four Make gates passed, and the absolute Makefile check passed from an
+  external directory.
+- Six isolated hostile mutations were rejected for matching selection, cleanup
+  targets, add fallthrough, regression registration, guidance, and plan status.
+- Python compilation, exact diff, generated-artifact, credential-signature,
+  conflict-marker, mode, binary, large-file, and whitespace audits passed.
 
 ## Risks
 

--- a/docs/plans/2026-06-17-matching-stream-rule-cleanup.md
+++ b/docs/plans/2026-06-17-matching-stream-rule-cleanup.md
@@ -1,0 +1,78 @@
+# Matching Stream Rule Cleanup
+
+status: planned
+
+## Problem
+
+Stream-rule synchronization reuses a desired worker-tagged rule only when it is
+the sole worker rule. If that exact rule exists alongside a stale or duplicate
+worker rule, startup creates another desired rule and then deletes every prior
+worker rule. The unnecessary add consumes remote rule capacity and repeated
+deletion failures can create additional desired rules on each retry.
+
+## Prioritized Requirements
+
+- P0. When at least one worker-tagged rule already has the desired value, retain
+  exactly one matching rule and delete only the other worker-tagged rules.
+- P0. Do not add a new rule on this cleanup-only path.
+- P0. Abort before filtering when cleanup deletion fails, preserving the
+  existing rule-list and deletion error boundaries.
+- P1. Preserve the existing add-first replacement path when no matching worker
+  rule exists so a rejected replacement cannot remove the active rule.
+- P1. Preserve unrelated rules, dry-run behavior, payload validation,
+  persistence, credentials, and dependency behavior.
+- P1. Add mutation-sensitive runtime and static contracts plus synchronized
+  maintenance guidance and completed verification evidence.
+
+## Implementation Units
+
+### U1. Retain one desired rule during cleanup
+
+**Files:** `sample_stream.py`
+
+Partition worker-tagged rules into desired matches and non-retained rules. If a
+desired match exists, retain one and delete only stale or duplicate worker rules
+without adding a replacement. Keep the current add-before-delete sequence when
+there is no desired match.
+
+### U2. No-network regression coverage
+
+**Files:** `test_sample_stream.py`
+
+Cover a desired rule alongside a stale rule, duplicate desired rules, unrelated
+rules, and cleanup deletion failure. Assertions must protect operation ordering,
+the retained rule identifier, absence of an add, deletion targets, and the
+filter-start boundary.
+
+### U3. Static contracts and guidance
+
+**Files:** `scripts/check-baseline.py`, `README.md`, `SECURITY.md`, `VISION.md`,
+`CHANGES.md`, `docs/plans/2026-06-17-matching-stream-rule-cleanup.md`
+
+Protect the retain-one partition, cleanup-only deletion behavior, public tests,
+guidance, and completed plan evidence against isolated hostile mutations.
+
+## Validation
+
+- Run focused synchronization tests, the complete no-network suite, all four
+  Make gates, and the absolute Makefile check from an external directory.
+- Reject isolated mutations of the matching-rule selection, cleanup deletion
+  targets, no-add guarantee, regressions, guidance, and completed plan status.
+- Audit the exact stacked diff, generated artifacts, credentials, conflict
+  markers, modes, binaries, large files, and whitespace before committing.
+
+## Scope Boundaries
+
+- Do not change Twitter/X authorization, rule tags, filter options, MongoDB
+  persistence, dependency pins, workflow lanes, or live-network behavior.
+- Do not delete unrelated rules or switch the no-match replacement path to
+  delete-first behavior.
+- Do not merge or close any stacked pull request.
+
+## Risks
+
+- Rule responses with missing identifiers cannot be safely targeted for
+  cleanup; existing API response assumptions remain unchanged.
+- Live Twitter/X rule quotas and partial remote failures remain outside the
+  credential-free test boundary.
+- This change is stacked on PR #12, which must remain open and merge first.

--- a/sample_stream.py
+++ b/sample_stream.py
@@ -83,7 +83,16 @@ def sync_stream_rule(stream, rule_value):
         raise RuntimeError("Twitter/X could not list existing stream rules")
     current = listed_rules.data or []
     worker_rules = [rule for rule in current if rule.tag == RULE_TAG]
-    if len(worker_rules) == 1 and worker_rules[0].value == rule_value:
+    matching_rules = [rule for rule in worker_rules if rule.value == rule_value]
+    if matching_rules:
+        retained_rule = matching_rules[0]
+        redundant_ids = [
+            rule.id for rule in worker_rules if rule is not retained_rule
+        ]
+        if redundant_ids:
+            delete_result = stream.delete_rules(redundant_ids)
+            if delete_result.errors:
+                raise RuntimeError("Twitter/X could not delete existing stream rules")
         return
     existing_ids = tagged_rule_ids(worker_rules)
     result = stream.add_rules(tweepy.StreamRule(value=rule_value, tag=RULE_TAG))

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -20,6 +20,7 @@ RULE_LIST_ERROR_PLAN = "docs/plans/2026-06-13-stream-rule-list-error-boundary.md
 LOCATION_INDEPENDENT_MAKE_PLAN = "docs/plans/2026-06-14-location-independent-make-gates.md"
 RULE_DELETE_ERROR_PLAN = "docs/plans/2026-06-15-stream-rule-delete-error-boundary.md"
 IDEMPOTENT_RULE_SYNC_PLAN = "docs/plans/2026-06-16-idempotent-stream-rule-sync.md"
+MATCHING_RULE_CLEANUP_PLAN = "docs/plans/2026-06-17-matching-stream-rule-cleanup.md"
 PRODUCTION_LOCK_SHA256 = "27ea76d7d0f7efea504ebcee475e411502bc775dceab3e10501563085d77ce1c"
 AUDIT_LOCK_SHA256 = "fc7ce7c6f13eee2008ea150facb1560903d6d12f4d6ad5245e68fdc3a75e607b"
 REQUIRED = [
@@ -54,6 +55,7 @@ REQUIRED = [
     LOCATION_INDEPENDENT_MAKE_PLAN,
     RULE_DELETE_ERROR_PLAN,
     IDEMPOTENT_RULE_SYNC_PLAN,
+    MATCHING_RULE_CLEANUP_PLAN,
     "requirements-audit.in",
     "requirements-audit.lock",
     "requirements.txt",
@@ -186,18 +188,29 @@ def main():
         "listed_rules = stream.get_rules()",
         "if listed_rules.errors:",
         "worker_rules = [rule for rule in current if rule.tag == RULE_TAG]",
-        "if len(worker_rules) == 1 and worker_rules[0].value == rule_value:",
-        "stream.add_rules(",
-        "delete_result = stream.delete_rules(existing_ids)",
-        "if delete_result.errors:",
+        "matching_rules = [rule for rule in worker_rules if rule.value == rule_value]",
+        "if matching_rules:",
+        "retained_rule = matching_rules[0]",
+        "rule.id for rule in worker_rules if rule is not retained_rule",
+        "if redundant_ids:",
+        "delete_result = stream.delete_rules(redundant_ids)",
     ]
-    if any(marker not in sync_source for marker in sync_markers) or not all(
+    matching_branch = sync_source[
+        sync_source.find("if matching_rules:"):sync_source.find("existing_ids =")
+    ]
+    replacement_branch = sync_source[sync_source.find("existing_ids ="):]
+    if (any(marker not in sync_source for marker in sync_markers) or not all(
         sync_source.find(left) < sync_source.find(right)
         for left, right in zip(sync_markers, sync_markers[1:])
-    ):
+    ) or "stream.add_rules(" in matching_branch or
+            "delete_result = stream.delete_rules(redundant_ids)" not in matching_branch or
+            "stream.add_rules(" not in replacement_branch or
+            "delete_result = stream.delete_rules(existing_ids)" not in replacement_branch or
+            replacement_branch.find("stream.add_rules(") >=
+            replacement_branch.find("delete_result = stream.delete_rules(existing_ids)")):
         failures.append(
-            "rule synchronization must reject list errors before mutation and "
-            "delete errors before filter startup"
+            "rule synchronization must retain one matching rule without adding "
+            "and keep add-first replacement when no match exists"
         )
 
     tests = read("test_sample_stream.py")
@@ -209,7 +222,9 @@ def main():
         "test_start_stream_configures_tagged_oscars_rule",
         "test_start_stream_replaces_only_worker_tagged_rules",
         "test_start_stream_reuses_single_matching_worker_rule",
-        "test_start_stream_replaces_duplicate_matching_worker_rules",
+        "test_start_stream_reuses_one_duplicate_matching_worker_rule",
+        "test_start_stream_reuses_matching_rule_while_deleting_stale_rule",
+        "test_matching_rule_cleanup_error_aborts_without_adding_or_filtering",
         "test_rejected_replacement_rule_preserves_existing_rule",
         "test_rule_list_error_aborts_before_remote_mutation",
         "test_rule_delete_error_aborts_before_filter_start",
@@ -217,7 +232,8 @@ def main():
         "FakeStreamingClient.delete_errors",
         "self.assertEqual([\"add\", \"delete\"], stream.rule_operations)",
         "self.assertEqual([], stream.rule_operations)",
-        "self.assertEqual([\"first\", \"second\"], stream.deleted_rule_ids)",
+        "self.assertEqual([\"second\"], stream.deleted_rule_ids)",
+        "self.assertEqual([\"stale\"], stream.deleted_rule_ids)",
         "self.assertIsNone(stream.filter_options)",
         "test_rule_terms_are_literal_and_bounded",
         "test_start_stream_accepts_single_custom_track_term",
@@ -396,9 +412,13 @@ def main():
         "does not prove",
         "absolute Makefile path works from another directory",
         "single matching tagged rule",
+        "matching stream rule cleanup",
     ]:
         if phrase.lower() not in docs.lower():
             failures.append(f"docs must mention {phrase}")
+    for path in ["README.md", "SECURITY.md", "VISION.md", "CHANGES.md"]:
+        if "matching stream rule cleanup" not in read(path).lower():
+            failures.append(f"{path} must document matching stream rule cleanup")
 
     plan = read(PLAN)
     if "status: completed" not in plan or "make check" not in plan:
@@ -669,6 +689,25 @@ def main():
     ]:
         if evidence not in idempotent_rule_verification:
             failures.append(f"idempotent rule verification must record {evidence}")
+
+    matching_cleanup_plan = read(MATCHING_RULE_CLEANUP_PLAN)
+    matching_cleanup_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", matching_cleanup_plan
+    )
+    matching_cleanup_verification = markdown_section(
+        matching_cleanup_plan, "Verification Completed"
+    )
+    if (matching_cleanup_status != ["completed"] or
+            "eight focused rule synchronization tests" not in matching_cleanup_verification or
+            "22 no-network tests" not in matching_cleanup_verification or
+            "All four Make gates passed" not in matching_cleanup_verification or
+            "external directory" not in matching_cleanup_verification or
+            "Six isolated hostile mutations were rejected" not in matching_cleanup_verification or
+            re.search(r"(?i)\b(?:pending|todo|tbd|not run|to complete)\b",
+                      matching_cleanup_verification)):
+        failures.append(
+            "matching stream rule cleanup plan must record completed verification"
+        )
 
     try:
         ET.parse(ROOT / "docs/readme-overview.svg")

--- a/test_sample_stream.py
+++ b/test_sample_stream.py
@@ -234,7 +234,7 @@ class SampleStreamTest(unittest.TestCase):
             stream.filter_options,
         )
 
-    def test_start_stream_replaces_duplicate_matching_worker_rules(self):
+    def test_start_stream_reuses_one_duplicate_matching_worker_rule(self):
         rules = [
             FakeStreamRule(value="#oscars", tag="oscars-sample-stream", id="first"),
             FakeStreamRule(value="#oscars", tag="oscars-sample-stream", id="second"),
@@ -243,9 +243,27 @@ class SampleStreamTest(unittest.TestCase):
 
         stream = sample_stream.start_stream()
 
-        self.assertEqual(["add", "delete"], stream.rule_operations)
-        self.assertEqual(["first", "second"], stream.deleted_rule_ids)
-        self.assertEqual("#oscars", stream.added_rules[0].value)
+        self.assertEqual(["delete"], stream.rule_operations)
+        self.assertEqual(["second"], stream.deleted_rule_ids)
+        self.assertEqual([], stream.added_rules)
+
+    def test_start_stream_reuses_matching_rule_while_deleting_stale_rule(self):
+        rules = [
+            FakeStreamRule(value="#oscars2025", tag="oscars-sample-stream", id="stale"),
+            FakeStreamRule(value="#oscars", tag="oscars-sample-stream", id="current"),
+            FakeStreamRule(value="#other", tag="another-worker", id="unrelated"),
+        ]
+        sample_stream = load_sample_stream(rules=rules)
+
+        stream = sample_stream.start_stream()
+
+        self.assertEqual(["delete"], stream.rule_operations)
+        self.assertEqual(["stale"], stream.deleted_rule_ids)
+        self.assertEqual([], stream.added_rules)
+        self.assertEqual(
+            {"expansions": ["author_id"], "user_fields": ["username"]},
+            stream.filter_options,
+        )
 
     def test_rejected_replacement_rule_preserves_existing_rule(self):
         rules = [FakeStreamRule(id="ours", tag="oscars-sample-stream")]
@@ -293,6 +311,23 @@ class SampleStreamTest(unittest.TestCase):
         self.assertEqual(1, len(stream.added_rules))
         self.assertIsNone(stream.filter_options)
         self.assertEqual([], stream.db.tweets.documents)
+
+    def test_matching_rule_cleanup_error_aborts_without_adding_or_filtering(self):
+        rules = [
+            FakeStreamRule(value="#oscars", tag="oscars-sample-stream", id="current"),
+            FakeStreamRule(value="#oscars2025", tag="oscars-sample-stream", id="stale"),
+        ]
+        sample_stream = load_sample_stream(rules=rules)
+        FakeStreamingClient.delete_errors = [{"message": "delete rejected"}]
+
+        with self.assertRaisesRegex(RuntimeError, "could not delete existing"):
+            sample_stream.start_stream()
+
+        stream = FakeStreamingClient.instances[-1]
+        self.assertEqual(["delete"], stream.rule_operations)
+        self.assertEqual(["stale"], stream.deleted_rule_ids)
+        self.assertEqual([], stream.added_rules)
+        self.assertIsNone(stream.filter_options)
 
     def test_rule_terms_are_literal_and_bounded(self):
         sample_stream = load_sample_stream()


### PR DESCRIPTION
## Summary

Stream startup now reuses an existing desired Twitter/X rule even when stale or duplicate worker rules also exist. Cleanup removes only the redundant worker rules instead of consuming capacity for another add.

Plan: `docs/plans/2026-06-17-matching-stream-rule-cleanup.md`

## Baseline

The previous convergence path reused a desired rule only when it was the sole worker-tagged rule. A desired rule alongside stale state caused another desired rule to be created before all previous worker rules were deleted, and repeated deletion failures could amplify that remote state.

## Improvements

- Retain one existing rule with the desired value.
- Delete only stale or duplicate worker-tagged rule IDs on the cleanup path.
- Return before replacement creation whenever a desired rule already exists.
- Preserve add-first replacement when no desired rule exists, along with unrelated-rule and filter-start boundaries.
- Protect the behavior with runtime regressions, static contracts, synchronized guidance, and completed plan evidence.

## Validation

- Eight focused stream-rule synchronization tests passed.
- The complete credential-free suite passed all 22 no-network tests.
- `make lint`, `make test`, `make build`, and `make check` passed.
- The absolute Makefile check passed from an external directory.
- Six isolated hostile mutations were rejected.
- Python compilation and exact diff, artifact, secret, conflict-marker, mode, binary, size, and whitespace audits passed.
- Compound Engineering review found no actionable issues.

## Risk

Live Twitter/X authorization, rule quotas, persistent remote state, and partial service failures were not exercised. The no-match path intentionally remains add-first so a rejected replacement cannot remove the active rule.

## Follow-Ups

This PR is stacked on PR #12 and should merge only after that dependency. Neither PR should be merged or closed without repository-owner authorization.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
