### PR TITLE
fix: make tweet persistence idempotent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-17
 
+- Made tweet persistence idempotent by upserting each accepted stream event
+  under its stable Twitter/X tweet ID.
 - Added matching stream rule cleanup that retains an existing desired rule while
   removing stale or duplicate worker-tagged rules without another add.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ python -m pip_audit --require-hashes --no-deps -r requirements.lock
   matching expanded `username` must be non-empty strings after trimming.
 - Twitter/X streaming statuses `420` and `429` disconnect the client instead
   of repeatedly reconnecting while rate limited.
-- MongoDB writes use PyMongo `insert_one`; tests preserve explicit falsy client
+- MongoDB writes use the stable tweet ID as `_id` with an idempotent PyMongo
+  upsert, so replayed deliveries replace one document instead of duplicating
+  it. Tests preserve explicit falsy client
   injection without contacting a database.
 - Local verification runs with Python bytecode writes disabled so no
   `__pycache__` output remains after the no-network gates.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,6 +73,8 @@ A single matching tagged rule is reused without remote mutations, reducing
 avoidable API failure exposure while duplicate or stale state still converges.
 Matching stream rule cleanup retains an existing desired rule and removes only
 redundant worker-tagged rules, limiting quota use and retry amplification.
+Accepted stream events require a stable tweet ID and use idempotent, ID-keyed
+MongoDB upserts so reconnect or redelivery does not amplify stored personal data.
 Use `python sample_stream.py --dry-run` to inspect normalized rule JSON without
 reading bearer-token or MongoDB environment values, constructing clients,
 mutating persistent API v2 rules, starting a stream, or writing documents.

--- a/VISION.md
+++ b/VISION.md
@@ -46,7 +46,8 @@ Priority:
   stale or duplicate worker-tagged state
 - Preserve matching stream rule cleanup so an existing desired rule is retained
   while stale and duplicate worker rules are removed without another add
-- Require expanded author identity before MongoDB storage through `insert_one`
+- Require stable tweet identity and expanded author identity before MongoDB
+  storage, and keep replayed deliveries idempotent through an ID-keyed upsert
 - Keep verification targets from leaving Python bytecode behind
 - Keep Python 3.10 and 3.12 hosted Linux validation credential-free and
   no-network

--- a/docs/plans/2026-06-17-idempotent-tweet-persistence.md
+++ b/docs/plans/2026-06-17-idempotent-tweet-persistence.md
@@ -1,0 +1,81 @@
+# Idempotent Tweet Persistence
+
+status: completed
+
+## Summary
+
+Persist each accepted Twitter/X v2 stream event under its stable tweet ID so
+replayed or redelivered events update one MongoDB document instead of creating
+duplicates.
+
+## Problem
+
+`OscarsStream.on_data` validates the v2 payload but discards `data.id` and
+always calls `insert_one`. Stream reconnects and remote redelivery can therefore
+store the same tweet more than once, while malformed or missing identifiers are
+currently indistinguishable from valid events.
+
+## Requirements
+
+- Require a non-empty string `data.id` before persistence.
+- Use the tweet ID as the MongoDB document `_id` and perform an idempotent
+  upsert rather than an unconditional insert.
+- Preserve normalized text, UTC observation time, and expanded username fields.
+- Ignore malformed or incomplete payloads without writing to MongoDB.
+- Prove that replaying the same event retains one document and that a changed
+  replay refreshes the stored fields.
+- Extend repository guidance, changelog evidence, and the static baseline so
+  removal of the ID or upsert contract is rejected.
+
+## Implementation Units
+
+- `sample_stream.py`: validate the tweet ID and persist with an ID-keyed upsert.
+- `test_sample_stream.py`: model Mongo upserts and cover first delivery,
+  duplicate replay, changed replay, and missing or malformed IDs.
+- `scripts/check-baseline.py`: enforce the ID validation, upsert, tests, docs,
+  and completed-plan contracts.
+- `README.md`, `SECURITY.md`, `VISION.md`, and `CHANGES.md`: document the
+  replay-safe persistence boundary and operational behavior.
+- `docs/plans/2026-06-17-idempotent-tweet-persistence.md`: record completed work
+  and actual verification after implementation.
+
+## Verification
+
+- Run focused unit tests and the full `make check` gate from the repository and
+  an external working directory.
+- Reject isolated mutations that remove ID validation, replace upsert with
+  insertion, drop `_id`, weaken replay assertions, or leave plan evidence
+  incomplete.
+- Audit the exact diff, generated artifacts, secrets, conflict markers, file
+  modes, and unintended dependency changes before committing.
+
+## Risks
+
+- Existing duplicate rows are not migrated or removed by this change.
+- MongoDB write failures continue to surface to the stream worker rather than
+  being silently swallowed.
+- The change remains stacked on PR #13 and must not merge or close existing pull
+  requests without explicit owner authorization.
+
+## Work Completed
+
+- Required a normalized, non-empty tweet ID before accepting a stream event.
+- Replaced unconditional insertion with an `_id`-keyed MongoDB update upsert so
+  replayed deliveries converge on one stored document without erasing fields
+  owned by downstream enrichment.
+- Added fake-client coverage for first delivery, exact replay, changed replay,
+  malformed IDs, normalized fields, and UTC observation timestamps.
+- Extended the static baseline and repository guidance for replay-safe storage.
+
+## Verification Completed
+
+- All 24 no-network tests passed, including duplicate, changed replay, and
+  distinct tweet identity cases.
+- Six isolated hostile mutations were rejected for missing ID validation,
+  unconditional insertion, missing document identity, disabled upsert, removed
+  replay coverage, and incomplete plan evidence.
+- `git diff --check` passed before the aggregate gates.
+- `timeout 300s make check` passed all 24 no-network tests and the static
+  baseline from the repository root.
+- `timeout 300s make -f <worktree>/Makefile check` passed the same suite from
+  an external working directory.

--- a/sample_stream.py
+++ b/sample_stream.py
@@ -139,17 +139,22 @@ class OscarsStream(tweepy.StreamingClient):
         tweet = payload.get("data") or {}
         if not isinstance(tweet, dict):
             return
+        tweet_id = clean_required_text(tweet.get("id"))
         text = clean_required_text(tweet.get("text"))
         author_id = clean_required_text(tweet.get("author_id"))
         username = expanded_username(payload, author_id)
-        if not text or not author_id or not username:
+        if not tweet_id or not text or not author_id or not username:
             return
 
-        self.db.tweets.insert_one({
-            "text": text,
-            "date": datetime.datetime.now(datetime.timezone.utc),
-            "screen_name": username,
-        })
+        self.db.tweets.update_one(
+            {"_id": tweet_id},
+            {"$set": {
+                "text": text,
+                "date": datetime.datetime.now(datetime.timezone.utc),
+                "screen_name": username,
+            }},
+            upsert=True,
+        )
 
     def on_request_error(self, status_code):
         if status_code in (420, 429):

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -21,6 +21,7 @@ LOCATION_INDEPENDENT_MAKE_PLAN = "docs/plans/2026-06-14-location-independent-mak
 RULE_DELETE_ERROR_PLAN = "docs/plans/2026-06-15-stream-rule-delete-error-boundary.md"
 IDEMPOTENT_RULE_SYNC_PLAN = "docs/plans/2026-06-16-idempotent-stream-rule-sync.md"
 MATCHING_RULE_CLEANUP_PLAN = "docs/plans/2026-06-17-matching-stream-rule-cleanup.md"
+IDEMPOTENT_TWEET_PERSISTENCE_PLAN = "docs/plans/2026-06-17-idempotent-tweet-persistence.md"
 PRODUCTION_LOCK_SHA256 = "27ea76d7d0f7efea504ebcee475e411502bc775dceab3e10501563085d77ce1c"
 AUDIT_LOCK_SHA256 = "fc7ce7c6f13eee2008ea150facb1560903d6d12f4d6ad5245e68fdc3a75e607b"
 REQUIRED = [
@@ -56,6 +57,7 @@ REQUIRED = [
     RULE_DELETE_ERROR_PLAN,
     IDEMPOTENT_RULE_SYNC_PLAN,
     MATCHING_RULE_CLEANUP_PLAN,
+    IDEMPOTENT_TWEET_PERSISTENCE_PLAN,
     "requirements-audit.in",
     "requirements-audit.lock",
     "requirements.txt",
@@ -152,7 +154,11 @@ def main():
         "mongo_client is not None",
         "config.mongo_url()",
         "config.bearer_token()",
-        "self.db.tweets.insert_one",
+        'tweet_id = clean_required_text(tweet.get("id"))',
+        'self.db.tweets.update_one(',
+        '{"_id": tweet_id}',
+        '{"$set": {',
+        "upsert=True",
         "if status_code in (420, 429)",
         "self.disconnect()",
         "tweepy.StreamRule(value=rule_value, tag=RULE_TAG)",
@@ -247,7 +253,7 @@ def main():
         "test_main_dry_run_emits_stable_json_for_repeated_track_terms",
         "test_main_without_dry_run_preserves_live_startup",
         "dry run must not construct a Twitter/X or MongoDB client",
-        "test_stream_inserts_minimal_v2_tweet_document",
+        "test_stream_persists_minimal_v2_tweet_document",
         "test_stream_ignores_malformed_or_incomplete_v2_payloads",
         "test_start_stream_rejects_more_than_one_hundred_track_terms",
     ]:
@@ -403,7 +409,7 @@ def main():
         "stream rate-limit",
         "hosted Linux",
         "StreamingClient",
-        "insert_one",
+        "ID-keyed upsert",
         "oscars-sample-stream",
         "dependency audit",
         "hash-locked",
@@ -419,6 +425,20 @@ def main():
     for path in ["README.md", "SECURITY.md", "VISION.md", "CHANGES.md"]:
         if "matching stream rule cleanup" not in read(path).lower():
             failures.append(f"{path} must document matching stream rule cleanup")
+        if "idempotent" not in read(path).lower():
+            failures.append(f"{path} must document idempotent tweet persistence")
+
+    tests = read("test_sample_stream.py")
+    for phrase in [
+        "def test_stream_replays_replace_the_same_tweet_document",
+        "def test_stream_persists_distinct_tweet_ids_separately",
+        "stream_payload(tweet_id=123)",
+        'self.assertEqual("100", document["_id"])',
+        'self.assertEqual("updated winner", document["text"])',
+        'self.assertEqual("reviewed", document["moderation_state"])',
+    ]:
+        if phrase not in tests:
+            failures.append(f"test_sample_stream.py must include {phrase}")
 
     plan = read(PLAN)
     if "status: completed" not in plan or "make check" not in plan:
@@ -707,6 +727,39 @@ def main():
                       matching_cleanup_verification)):
         failures.append(
             "matching stream rule cleanup plan must record completed verification"
+        )
+
+    tweet_persistence_plan = read(IDEMPOTENT_TWEET_PERSISTENCE_PLAN)
+    tweet_persistence_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", tweet_persistence_plan
+    )
+    tweet_persistence_work = markdown_section(
+        tweet_persistence_plan, "Work Completed"
+    )
+    tweet_persistence_verification = markdown_section(
+        tweet_persistence_plan, "Verification Completed"
+    )
+    if tweet_persistence_status != ["completed"] or not tweet_persistence_work:
+        failures.append(
+            "idempotent tweet persistence plan must record completed work"
+        )
+    for evidence in [
+        "24 no-network tests",
+        "make check",
+        "external working directory",
+        "isolated hostile mutations",
+        "git diff --check",
+    ]:
+        if evidence not in tweet_persistence_verification:
+            failures.append(
+                f"idempotent tweet persistence verification must record {evidence}"
+            )
+    if re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run|to complete)\b",
+        tweet_persistence_verification,
+    ):
+        failures.append(
+            "idempotent tweet persistence plan must record completed verification"
         )
 
     try:

--- a/test_sample_stream.py
+++ b/test_sample_stream.py
@@ -66,8 +66,15 @@ class FakeTweets:
     def __init__(self):
         self.documents = []
 
-    def insert_one(self, document):
-        self.documents.append(document)
+    def update_one(self, query, update, upsert=False):
+        if not upsert:
+            raise AssertionError("tweet persistence must use an upsert")
+        fields = update["$set"]
+        for index, existing in enumerate(self.documents):
+            if all(existing.get(key) == value for key, value in query.items()):
+                self.documents[index] = {**existing, **fields}
+                return
+        self.documents.append({**query, **fields})
 
 
 class FakeMongoClient:
@@ -113,9 +120,14 @@ def load_sample_stream(overrides=None, rules=None):
     return importlib.import_module("sample_stream")
 
 
-def stream_payload(text="  hello oscars  ", author_id="42", username=" academy "):
+def stream_payload(
+    text="  hello oscars  ",
+    author_id="42",
+    username=" academy ",
+    tweet_id="100",
+):
     return json.dumps({
-        "data": {"id": "100", "text": text, "author_id": author_id},
+        "data": {"id": tweet_id, "text": text, "author_id": author_id},
         "includes": {"users": [{"id": author_id, "username": username}]},
     })
 
@@ -366,7 +378,7 @@ class SampleStreamTest(unittest.TestCase):
 
         self.assertEqual("bearer-fallback", sample_stream.config.bearer_token())
 
-    def test_stream_inserts_minimal_v2_tweet_document(self):
+    def test_stream_persists_minimal_v2_tweet_document(self):
         sample_stream = load_sample_stream()
         client = FakeMongoClient("mongodb://example.invalid/db")
         stream = sample_stream.OscarsStream("bearer", mongo_client=client)
@@ -375,6 +387,7 @@ class SampleStreamTest(unittest.TestCase):
 
         self.assertEqual(1, len(client.TweetDB.tweets.documents))
         document = client.TweetDB.tweets.documents[0]
+        self.assertEqual("100", document["_id"])
         self.assertEqual("hello oscars", document["text"])
         self.assertEqual("academy", document["screen_name"])
         self.assertIsNotNone(document["date"].tzinfo)
@@ -414,6 +427,8 @@ class SampleStreamTest(unittest.TestCase):
             stream_payload(text=123),
             stream_payload(author_id=123),
             stream_payload(username=123),
+            stream_payload(tweet_id=123),
+            stream_payload(tweet_id="   "),
             stream_payload(text="   "),
             '{"data":{"text":"missing author"},"includes":{"users":[]}}',
             '{"data":{"text":"missing user","author_id":"42"},"includes":{"users":[]}}',
@@ -424,6 +439,35 @@ class SampleStreamTest(unittest.TestCase):
             with self.subTest(payload=payload):
                 stream.on_data(payload)
         self.assertEqual([], client.TweetDB.tweets.documents)
+
+    def test_stream_replays_replace_the_same_tweet_document(self):
+        sample_stream = load_sample_stream()
+        client = FakeMongoClient("mongodb://example.invalid/db")
+        stream = sample_stream.OscarsStream("bearer", mongo_client=client)
+
+        stream.on_data(stream_payload())
+        client.TweetDB.tweets.documents[0]["moderation_state"] = "reviewed"
+        stream.on_data(stream_payload(text=" updated winner ", username=" host "))
+
+        self.assertEqual(1, len(client.TweetDB.tweets.documents))
+        document = client.TweetDB.tweets.documents[0]
+        self.assertEqual("100", document["_id"])
+        self.assertEqual("updated winner", document["text"])
+        self.assertEqual("host", document["screen_name"])
+        self.assertEqual("reviewed", document["moderation_state"])
+
+    def test_stream_persists_distinct_tweet_ids_separately(self):
+        sample_stream = load_sample_stream()
+        client = FakeMongoClient("mongodb://example.invalid/db")
+        stream = sample_stream.OscarsStream("bearer", mongo_client=client)
+
+        stream.on_data(stream_payload(tweet_id="100"))
+        stream.on_data(stream_payload(tweet_id="101", text=" second tweet "))
+
+        self.assertEqual(
+            {"100", "101"},
+            {document["_id"] for document in client.TweetDB.tweets.documents},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Make replayed Twitter/X stream deliveries converge on one MongoDB document instead of creating duplicate stored posts. Each accepted event must include a normalized tweet ID, which becomes the document identity for an atomic update upsert.

## Baseline

The worker previously inserted every accepted delivery as a new document. Stream retries or replayed events could therefore create duplicate records for the same tweet, inflate downstream counts, and repeat enrichment work. The persistence path also lacked a fail-closed requirement for a normalized tweet ID.

## Improvements

- Normalize and validate the tweet ID before any persistence call.
- Use the tweet ID as MongoDB `_id` so replayed events share one durable identity.
- Perform an atomic update with upsert semantics instead of unconditional insertion.
- Update only worker-owned fields so downstream enrichment on an existing document is preserved.
- Keep distinct tweet IDs as distinct records and reject malformed or missing IDs.
- Add replay, distinct-ID, selector, upsert, malformed-payload, and mutation-sensitive evidence coverage.
- Document the persistence contract, operational signals, and rollback boundary.

## Validation

- `timeout 300s make check` passed with 24 no-network tests and the static baseline.
- External-directory `make check` through the absolute Makefile path passed.
- Six isolated hostile mutations covering ID validation, selector identity, upsert behavior, replay coverage, and plan evidence were exercised.
- Exact diff, artifact, credential-signature, dependency, binary, mode, conflict-marker, and whitespace audits passed.
- All six exact-head GitHub Actions checks passed for `db842477d312c47c0205bdaafc4bba0d6d764271`, including Python 3.10, Python 3.12, and dependency audits for push and pull-request runs.

## Risk

- No live Twitter/X stream or production MongoDB instance was exercised; tests use controlled fake clients and no network access.
- The change is stacked on `lfg/oscars-matching-rule-cleanup-20260617` and depends on that branch's stream-rule behavior remaining intact.
- Existing deployments with duplicate documents are not backfilled or deduplicated by this change.
- After deployment, monitor worker logs for `DuplicateKeyError`, `OperationFailure`, and unexpected callback exceptions. Compare accepted-event counts with unique-document growth, sample `_id` values, and verify downstream-owned fields survive redelivery. Roll back on sustained write errors, missing IDs, or enrichment loss.

## Follow-Ups

- Run a controlled staging replay against a MongoDB-compatible service and verify unique-document counts and retained enrichment fields.
- Define and execute a separately reviewed cleanup plan for historical duplicate documents if production data contains them.
- Observe the first 24 hours after deployment and record stream throughput, unique-document growth, and MongoDB write-error results.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
