### PR TITLE
fix: harden Oscars make root resolution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-21
+
+- Made absolute Makefile verification safe for spaces and apostrophes,
+  ignored caller-provided `REPO_ROOT` values, and rejected command-line or
+  environment `MAKEFILE_LIST` injection before stream gates run.
+- Added root-policy regressions for every public Make target.
+
 ## 2026-06-17
 
 - Made tweet persistence idempotent by upserting each accepted stream event

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,11 @@
 
 ## 2026-06-21
 
-- Made absolute Makefile verification safe for spaces and apostrophes,
+- Made absolute Makefile verification safe for spaces, apostrophes, quotes,
+  backticks, and shell metacharacters,
   ignored caller-provided `REPO_ROOT` values, and rejected command-line or
   environment `MAKEFILE_LIST` injection before stream gates run.
-- Added root-policy regressions for every public Make target.
+- Added live command-substitution regressions for every public Make target.
 
 ## 2026-06-17
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ifneq ($(origin MAKEFILE_LIST),file)
 $(error MAKEFILE_LIST must not be overridden)
 endif
 override REPO_ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
+override SHELL_REPO_ROOT := '$(subst ','"'"',$(REPO_ROOT))'
 
 PYTHON ?= python3
 .PHONY: build check lint root-test static-check test verify
@@ -15,10 +16,10 @@ build: static-check
 lint: static-check
 
 test:
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m unittest discover -v -s "$(REPO_ROOT)"
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m unittest discover -v -s $(SHELL_REPO_ROOT)
 
 static-check:
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) "$(REPO_ROOT)/scripts/check-baseline.py"
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) $(SHELL_REPO_ROOT)/scripts/check-baseline.py
 
 root-test:
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) "$(REPO_ROOT)/scripts/test-makefile-root.py"
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) $(SHELL_REPO_ROOT)/scripts/test-makefile-root.py

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
-.PHONY: build check lint static-check test verify
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override REPO_ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
 
 PYTHON ?= python3
-override REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+.PHONY: build check lint root-test static-check test verify
 
-check: test lint
+check: test lint root-test
 
 verify: check
 
@@ -16,3 +19,6 @@ test:
 
 static-check:
 	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) "$(REPO_ROOT)/scripts/check-baseline.py"
+
+root-test:
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) "$(REPO_ROOT)/scripts/test-makefile-root.py"

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
   changing stream startup, credential handling, MongoDB writes, or the
   `#oscars` filter.
 - Standard Make aliases resolve unittest discovery and checker paths from
-  `Makefile`, so an absolute Makefile path works from another directory.
+  `Makefile`, so an absolute Makefile path works from another directory,
+  including paths with spaces or apostrophes. Caller `REPO_ROOT` values are
+  ignored, and `MAKEFILE_LIST` overrides fail closed before verification runs.
 - See `CHANGES.md` and `docs/plans/2026-06-08-oscars-stream-baseline.md` for
   the current worker baseline.
 - See `docs/plans/2026-06-10-hosted-no-network-validation.md` for the hosted

--- a/README.md
+++ b/README.md
@@ -170,8 +170,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
   `#oscars` filter.
 - Standard Make aliases resolve unittest discovery and checker paths from
   `Makefile`, so an absolute Makefile path works from another directory,
-  including paths with spaces or apostrophes. Caller `REPO_ROOT` values are
-  ignored, and `MAKEFILE_LIST` overrides fail closed before verification runs.
+  including paths with whitespace, quotes, apostrophes, or backticks. The
+  resolved root is shell-quoted before recipe use, caller `REPO_ROOT` values
+  are ignored, and `MAKEFILE_LIST` overrides fail closed before verification.
 - See `CHANGES.md` and `docs/plans/2026-06-08-oscars-stream-baseline.md` for
   the current worker baseline.
 - See `docs/plans/2026-06-10-hosted-no-network-validation.md` for the hosted

--- a/docs/plans/2026-06-21-safe-make-root.md
+++ b/docs/plans/2026-06-21-safe-make-root.md
@@ -9,7 +9,8 @@ values could redirect no-network stream verification outside the checkout.
 
 - Resolve the raw Makefile path with POSIX-compatible system tooling.
 - Reject non-file origins for GNU Make's automatic `MAKEFILE_LIST` value.
-- Add dependency-free regressions for every public target and override channel.
+- Shell-quote the resolved root once before any recipe uses it.
+- Add dependency-free dry-run and live command-substitution regressions.
 
 ## Validation
 

--- a/docs/plans/2026-06-21-safe-make-root.md
+++ b/docs/plans/2026-06-21-safe-make-root.md
@@ -1,0 +1,17 @@
+# Safe Make Root
+
+## Problem
+
+Whitespace-splitting Make functions and caller-controlled `MAKEFILE_LIST`
+values could redirect no-network stream verification outside the checkout.
+
+## Change
+
+- Resolve the raw Makefile path with POSIX-compatible system tooling.
+- Reject non-file origins for GNU Make's automatic `MAKEFILE_LIST` value.
+- Add dependency-free regressions for every public target and override channel.
+
+## Validation
+
+- Run all no-network stream tests, static checks, and root-policy tests.
+- Confirm Python 3.10/3.12, dependency audit, and CodeQL pass at the exact PR head.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -18,6 +18,7 @@ HASH_LOCK_PLAN = "docs/plans/2026-06-12-hash-locked-dependency-installs.md"
 DRY_RUN_PLAN = "docs/plans/2026-06-13-dry-run-stream-rule.md"
 RULE_LIST_ERROR_PLAN = "docs/plans/2026-06-13-stream-rule-list-error-boundary.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = "docs/plans/2026-06-14-location-independent-make-gates.md"
+SAFE_MAKE_ROOT_PLAN = "docs/plans/2026-06-21-safe-make-root.md"
 RULE_DELETE_ERROR_PLAN = "docs/plans/2026-06-15-stream-rule-delete-error-boundary.md"
 IDEMPOTENT_RULE_SYNC_PLAN = "docs/plans/2026-06-16-idempotent-stream-rule-sync.md"
 MATCHING_RULE_CLEANUP_PLAN = "docs/plans/2026-06-17-matching-stream-rule-cleanup.md"
@@ -55,6 +56,7 @@ REQUIRED = [
     DRY_RUN_PLAN,
     RULE_LIST_ERROR_PLAN,
     LOCATION_INDEPENDENT_MAKE_PLAN,
+    SAFE_MAKE_ROOT_PLAN,
     RULE_DELETE_ERROR_PLAN,
     IDEMPOTENT_RULE_SYNC_PLAN,
     MATCHING_RULE_CLEANUP_PLAN,
@@ -65,6 +67,7 @@ REQUIRED = [
     "requirements.lock",
     "sample_stream.py",
     "scripts/check-baseline.py",
+    "scripts/test-makefile-root.py",
     "test_sample_stream.py",
 ]
 
@@ -289,9 +292,14 @@ def main():
     makefile = read("Makefile")
     for phrase in [
         "PYTHON ?= python3",
-        "override REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))",
+        "ifneq ($(origin MAKEFILE_LIST),file)",
+        "$(error MAKEFILE_LIST must not be overridden)",
+        "override REPO_ROOT := $(shell path=",
+        'CDPATH= cd -- "$$directory" && /bin/pwd -P)',
         'PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m unittest discover -v -s "$(REPO_ROOT)"',
         'PYTHONDONTWRITEBYTECODE=1 $(PYTHON) "$(REPO_ROOT)/scripts/check-baseline.py"',
+        'PYTHONDONTWRITEBYTECODE=1 $(PYTHON) "$(REPO_ROOT)/scripts/test-makefile-root.py"',
+        "check: test lint root-test",
         "lint: static-check",
         "build: static-check",
         "verify: check",

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -295,10 +295,11 @@ def main():
         "ifneq ($(origin MAKEFILE_LIST),file)",
         "$(error MAKEFILE_LIST must not be overridden)",
         "override REPO_ROOT := $(shell path=",
+        "override SHELL_REPO_ROOT :=",
         'CDPATH= cd -- "$$directory" && /bin/pwd -P)',
-        'PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m unittest discover -v -s "$(REPO_ROOT)"',
-        'PYTHONDONTWRITEBYTECODE=1 $(PYTHON) "$(REPO_ROOT)/scripts/check-baseline.py"',
-        'PYTHONDONTWRITEBYTECODE=1 $(PYTHON) "$(REPO_ROOT)/scripts/test-makefile-root.py"',
+        "PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m unittest discover -v -s $(SHELL_REPO_ROOT)",
+        "PYTHONDONTWRITEBYTECODE=1 $(PYTHON) $(SHELL_REPO_ROOT)/scripts/check-baseline.py",
+        "PYTHONDONTWRITEBYTECODE=1 $(PYTHON) $(SHELL_REPO_ROOT)/scripts/test-makefile-root.py",
         "check: test lint root-test",
         "lint: static-check",
         "build: static-check",
@@ -306,6 +307,19 @@ def main():
     ]:
         if phrase not in makefile:
             failures.append(f"Makefile must include {phrase}")
+
+    root_test = read("scripts/test-makefile-root.py")
+    for phrase in [
+        "import shlex",
+        "return result, shlex.quote(str(checkout.resolve()))",
+        "test_live_root_path_does_not_execute_shell_metacharacters",
+        "`touch BACKTICK_PWNED`",
+        '" ; touch QUOTE_PWNED ; echo "',
+        "self.assertFalse((checkout.parent / marker_name).exists(), result.stdout)",
+        'self.assertIn("live root stub passed", result.stdout)',
+    ]:
+        if phrase not in root_test:
+            failures.append(f"Make root regression must include {phrase}")
 
     workflow = read(".github/workflows/check.yml")
     codeowners = read(".github/CODEOWNERS")

--- a/scripts/test-makefile-root.py
+++ b/scripts/test-makefile-root.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class MakefileRootTests(unittest.TestCase):
+    def run_make(self, *arguments, environment=None):
+        with tempfile.TemporaryDirectory(prefix="Oscars Stream's [gate] ") as directory:
+            checkout = Path(directory)
+            makefile = checkout / "Makefile"
+            makefile.write_text(
+                (ROOT / "Makefile").read_text(encoding="utf-8"), encoding="utf-8"
+            )
+            env = {"PATH": os.environ.get("PATH", "")}
+            if environment:
+                env.update(environment)
+            return subprocess.run(
+                ["make", "--no-print-directory", "-n", "-f", str(makefile), *arguments],
+                cwd=checkout.parent,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=False,
+                env=env,
+            )
+
+    def test_all_targets_preserve_spaced_absolute_makefile_path(self):
+        targets = ("build", "check", "lint", "root-test", "static-check", "test", "verify")
+        for target in targets:
+            for name, arguments, environment in (
+                ("none", (target,), None),
+                ("command", (target, "REPO_ROOT=/tmp/attacker-root"), None),
+                ("environment", (target,), {"REPO_ROOT": "/tmp/attacker-root"}),
+            ):
+                with self.subTest(target=target, override=name):
+                    result = self.run_make(*arguments, environment=environment)
+                    self.assertEqual(result.returncode, 0, result.stdout)
+                    self.assertNotIn("/tmp/attacker-root", result.stdout)
+                    self.assertIn("Oscars Stream's [gate] ", result.stdout)
+
+    def test_command_line_makefile_list_override_fails_closed(self):
+        result = self.run_make("verify", "MAKEFILE_LIST=/tmp/untrusted")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("MAKEFILE_LIST must not be overridden", result.stdout)
+
+    def test_environment_makefile_list_override_fails_closed(self):
+        result = self.run_make("-e", "verify", environment={"MAKEFILE_LIST": "/tmp/untrusted"})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("MAKEFILE_LIST must not be overridden", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-makefile-root.py
+++ b/scripts/test-makefile-root.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 from pathlib import Path
+import shlex
 import subprocess
 import tempfile
 import unittest
@@ -20,7 +21,7 @@ class MakefileRootTests(unittest.TestCase):
             env = {"PATH": os.environ.get("PATH", "")}
             if environment:
                 env.update(environment)
-            return subprocess.run(
+            result = subprocess.run(
                 ["make", "--no-print-directory", "-n", "-f", str(makefile), *arguments],
                 cwd=checkout.parent,
                 stdout=subprocess.PIPE,
@@ -29,6 +30,32 @@ class MakefileRootTests(unittest.TestCase):
                 check=False,
                 env=env,
             )
+            return result, shlex.quote(str(checkout.resolve()))
+
+    def assert_live_root_path_is_literal(self, checkout_name, marker_name):
+        with tempfile.TemporaryDirectory() as parent:
+            checkout = Path(parent) / checkout_name
+            scripts = checkout / "scripts"
+            scripts.mkdir(parents=True)
+            makefile = checkout / "Makefile"
+            makefile.write_text(
+                (ROOT / "Makefile").read_text(encoding="utf-8"), encoding="utf-8"
+            )
+            (scripts / "test-makefile-root.py").write_text(
+                "print('live root stub passed')\n", encoding="utf-8"
+            )
+            result = subprocess.run(
+                ["make", "--no-print-directory", "-f", str(makefile), "root-test"],
+                cwd=checkout.parent,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=False,
+                env={"PATH": os.environ.get("PATH", "")},
+            )
+            self.assertEqual(result.returncode, 0, result.stdout)
+            self.assertFalse((checkout.parent / marker_name).exists(), result.stdout)
+            self.assertIn("live root stub passed", result.stdout)
 
     def test_all_targets_preserve_spaced_absolute_makefile_path(self):
         targets = ("build", "check", "lint", "root-test", "static-check", "test", "verify")
@@ -39,20 +66,28 @@ class MakefileRootTests(unittest.TestCase):
                 ("environment", (target,), {"REPO_ROOT": "/tmp/attacker-root"}),
             ):
                 with self.subTest(target=target, override=name):
-                    result = self.run_make(*arguments, environment=environment)
+                    result, expected_root = self.run_make(*arguments, environment=environment)
                     self.assertEqual(result.returncode, 0, result.stdout)
                     self.assertNotIn("/tmp/attacker-root", result.stdout)
-                    self.assertIn("Oscars Stream's [gate] ", result.stdout)
+                    self.assertIn(expected_root, result.stdout)
 
     def test_command_line_makefile_list_override_fails_closed(self):
-        result = self.run_make("verify", "MAKEFILE_LIST=/tmp/untrusted")
+        result, _ = self.run_make("verify", "MAKEFILE_LIST=/tmp/untrusted")
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("MAKEFILE_LIST must not be overridden", result.stdout)
 
     def test_environment_makefile_list_override_fails_closed(self):
-        result = self.run_make("-e", "verify", environment={"MAKEFILE_LIST": "/tmp/untrusted"})
+        result, _ = self.run_make("-e", "verify", environment={"MAKEFILE_LIST": "/tmp/untrusted"})
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("MAKEFILE_LIST must not be overridden", result.stdout)
+
+    def test_live_root_path_does_not_execute_shell_metacharacters(self):
+        for checkout_name, marker_name in (
+            ("Oscars backtick `touch BACKTICK_PWNED` case", "BACKTICK_PWNED"),
+            ('Oscars quote " ; touch QUOTE_PWNED ; echo " case', "QUOTE_PWNED"),
+        ):
+            with self.subTest(checkout_name=checkout_name):
+                self.assert_live_root_path_is_literal(checkout_name, marker_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

No-network stream verification can no longer be redirected outside the checkout through whitespace-sensitive absolute paths or caller-controlled Make variables. Paths containing spaces or apostrophes remain supported, caller `REPO_ROOT` values are ignored, and `MAKEFILE_LIST` injection fails before tests or static checks execute.

## Baseline

- `make check` passed 24 no-network stream tests and the static baseline at merged `master` head `e4196efcc1cf572e6b31417695fdc792843b4541`.
- Command-line and `make -e` environment `MAKEFILE_LIST=/tmp/untrusted` redirected dry-run verification to `/tmp` and exited successfully.

## Improvements

### Tests

- Adds regression coverage for all seven Make targets across normal, command-line `REPO_ROOT`, and environment `REPO_ROOT` inputs.
- Covers paths containing spaces, brackets, and an apostrophe, plus both `MAKEFILE_LIST` injection channels.
- Runs the root-policy suite from `check` and `verify`.

### Security

- Prevents verification from resolving caller-selected tests or checker scripts.
- Leaves Twitter/X, MongoDB, persistence, rule synchronization, dependencies, and credentials unchanged.

### Documentation

- Records the boundary and validation scope in repository maintenance notes.

## Validation

Passed at `a247b9d09ce257d6af38a4550aaded12b56a85da` with Python 3.12.8:

- `make check`, `make lint`, `make test`, `make build`, `make verify`, `make root-test`
- 24 no-network stream tests
- 3 root-policy methods covering 21 target/override cases plus both injection channels
- `git diff --check`, `git fsck --strict --no-dangling`
- Redacted Gitleaks 8.30.1 scan: no leaks found

Hosted validation passed: push and pull-request Python 3.10 and 3.12 jobs,
both dependency-audit jobs, Analyze (actions), Analyze (python), and the
CodeQL aggregate completed successfully.

## Risk

- Runtime stream behavior is unchanged.
- The resolver requires standard `/usr/bin/sed`, `/usr/bin/dirname`, and `/bin/pwd` on supported hosts.
- Live Twitter/X authorization, streaming, remote rule mutation, and MongoDB access remain intentionally untested.

## Follow-Ups

- Continue validating live service behavior only with dedicated credentials and isolated non-production resources.

## Post-Deploy Monitoring & Validation

No production monitoring is required because this affects verification only. Any hosted compatibility, audit, or root-policy failure should block merge and be mitigated by reverting this commit.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.4-000000)

