### PR TITLE
fix: preserve stream request error reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@ v2 stream worker for the `#oscars` sample.
 - Persist tweets with `update_one` and `upsert=True` against the tweet ID, and
   preserve explicit falsy-client injection.
 - Disconnect on stream rate limits 420 and 429.
+- Preserve Tweepy's base request-error reporting before applying local
+  disconnect decisions.
 - Do not commit bearer tokens, MongoDB URLs, captured posts, or local env files.
 
 ## PR / Change Guidance

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,53 @@
 # Changes
 
+## 2026-06-26 13:43:18 PDT - P1 - Preserve stream HTTP error reporting
+
+### Summary
+
+Restored Tweepy's base request-error callback so HTTP status failures remain
+observable while the worker keeps its existing 420/429 disconnect policy.
+
+### Work completed
+
+- Delegated every request error to `StreamingClient.on_request_error` before
+  applying the worker's local rate-limit decision.
+- Added a no-network regression covering retryable and rate-limit statuses.
+- Extended static contracts and operator guidance for the reporting boundary.
+
+### Threads
+
+- None; the focused callback and verification work was completed directly.
+
+### Files changed
+
+- `sample_stream.py` — preserve Tweepy's request-error reporting.
+- `test_sample_stream.py` — model and assert the base callback handoff.
+- `scripts/check-baseline.py` — enforce source, test, and plan contracts.
+- `README.md`, `SECURITY.md`, `VISION.md`, `AGENTS.md`, and
+  `docs/plans/2026-06-26-request-error-reporting.md` — document behavior and
+  verification.
+
+### Validation
+
+- Focused request-error tests — passed.
+- Full no-network, static, external-Make, mutation, and dependency checks —
+  recorded in the completed implementation plan.
+
+### Bugs / findings
+
+- P1 fixed: overriding `on_request_error` previously suppressed Tweepy's HTTP
+  status diagnostics for authorization, upstream, and rate-limit failures.
+
+### Blockers
+
+- Live Twitter/X authorization and response handling remain intentionally
+  outside the credential-free no-network test boundary.
+
+### Next action
+
+- Exercise the documented credentialed smoke path in an isolated test project
+  before production use.
+
 ## 2026-06-21
 
 - Made absolute Makefile verification safe for spaces, apostrophes, quotes,

--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ python -m pip_audit --require-hashes --no-deps -r requirements.lock
 - API v2 author expansion is required before storage: tweet `text` and the
   matching expanded `username` must be non-empty strings after trimming.
 - Twitter/X streaming statuses `420` and `429` disconnect the client instead
-  of repeatedly reconnecting while rate limited.
+  of repeatedly reconnecting while rate limited. Every HTTP request error is
+  still reported through Tweepy's callback before that local disconnect
+  decision, so authorization and upstream failures remain visible.
 - MongoDB writes use the stable tweet ID as `_id` with an idempotent PyMongo
   upsert, so replayed deliveries replace one document instead of duplicating
   it. Tests preserve explicit falsy client

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,6 +60,8 @@ Explicit MongoDB client injection should be honored in no-network tests so fake
 clients cannot fall through to configured MongoDB URLs.
 Legacy stream rate-limit status `420` should disconnect instead of entering a
 reconnect loop that escalates upstream backoff.
+HTTP request errors should still pass through Tweepy's base callback so status
+failures remain observable without logging response bodies or credentials.
 Python bytecode is local tooling output and should not remain after no-network
 verification gates.
 Persistent API v2 rules are project-wide state. The worker may replace only

--- a/VISION.md
+++ b/VISION.md
@@ -39,6 +39,8 @@ Priority:
 - Keep non-string raw stream payloads non-fatal
 - Keep explicit MongoDB client injection reliable for no-network tests
 - Keep API v2 stream rate-limit errors from reconnecting indefinitely
+- Keep every stream request error observable through Tweepy's status callback
+  before applying local disconnect policy
 - Keep rule replacement scoped to the `oscars-sample-stream` tag
 - Keep failed persistent-rule discovery ahead of add, delete, and filter calls
 - Keep failed tagged-rule deletion visible before filter startup

--- a/docs/plans/2026-06-26-request-error-reporting.md
+++ b/docs/plans/2026-06-26-request-error-reporting.md
@@ -1,0 +1,45 @@
+# Stream Request Error Reporting
+
+status: completed
+
+## Summary
+
+Preserve Tweepy's HTTP status reporting when the worker applies its own
+rate-limit disconnect policy.
+
+## Problem
+
+`OscarsStream.on_request_error` replaced the base callback and only handled
+statuses 420 and 429. Other request failures retained Tweepy's bounded retry
+behavior but lost the base status diagnostic, leaving authorization and
+upstream failures silent.
+
+## Design
+
+Call `super().on_request_error(status_code)` before the local disconnect check.
+This keeps logging ownership and formatting in Tweepy, preserves existing retry
+semantics, and does not expose response bodies or credential values. Custom
+printing was rejected because it would duplicate dependency behavior, and
+changing which statuses retry was rejected as unrelated policy churn.
+
+## Implementation
+
+- Added a fake base callback that records observed statuses.
+- Added a failing no-network regression for status 500 and status 429.
+- Delegated every request error to Tweepy before disconnecting on 420 or 429.
+- Added static and documentation contracts for the callback ordering.
+
+## Verification Completed
+
+- The focused regression failed before the implementation because neither
+  status reached the fake Tweepy callback, then passed after the superclass
+  handoff.
+- All 25 no-network tests passed.
+- `make check` passed from the repository root.
+- Absolute-Make verification passed from an external working directory.
+- An isolated hostile rollback mutation removing the superclass handoff was
+  rejected by the focused regression.
+- The exact hash-locked dependency graph installed and imported successfully;
+  the pinned dependency audit reported no known vulnerabilities.
+- `git diff --check`, Python compilation, generated-artifact, conflict-marker,
+  and secret-shaped-content audits passed.

--- a/sample_stream.py
+++ b/sample_stream.py
@@ -157,6 +157,7 @@ class OscarsStream(tweepy.StreamingClient):
         )
 
     def on_request_error(self, status_code):
+        super().on_request_error(status_code)
         if status_code in (420, 429):
             self.disconnect()
 

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -23,6 +23,7 @@ RULE_DELETE_ERROR_PLAN = "docs/plans/2026-06-15-stream-rule-delete-error-boundar
 IDEMPOTENT_RULE_SYNC_PLAN = "docs/plans/2026-06-16-idempotent-stream-rule-sync.md"
 MATCHING_RULE_CLEANUP_PLAN = "docs/plans/2026-06-17-matching-stream-rule-cleanup.md"
 IDEMPOTENT_TWEET_PERSISTENCE_PLAN = "docs/plans/2026-06-17-idempotent-tweet-persistence.md"
+REQUEST_ERROR_REPORTING_PLAN = "docs/plans/2026-06-26-request-error-reporting.md"
 PRODUCTION_LOCK_SHA256 = "27ea76d7d0f7efea504ebcee475e411502bc775dceab3e10501563085d77ce1c"
 AUDIT_LOCK_SHA256 = "fc7ce7c6f13eee2008ea150facb1560903d6d12f4d6ad5245e68fdc3a75e607b"
 REQUIRED = [
@@ -61,6 +62,7 @@ REQUIRED = [
     IDEMPOTENT_RULE_SYNC_PLAN,
     MATCHING_RULE_CLEANUP_PLAN,
     IDEMPOTENT_TWEET_PERSISTENCE_PLAN,
+    REQUEST_ERROR_REPORTING_PLAN,
     "requirements-audit.in",
     "requirements-audit.lock",
     "requirements.txt",
@@ -164,6 +166,7 @@ def main():
         '{"$set": {',
         "upsert=True",
         "if status_code in (420, 429)",
+        "super().on_request_error(status_code)",
         "self.disconnect()",
         "tweepy.StreamRule(value=rule_value, tag=RULE_TAG)",
         "if listed_rules.errors:",
@@ -252,6 +255,8 @@ def main():
         "FalsyMongoClient",
         "test_stream_uses_explicit_falsy_mongo_client",
         "test_stream_disconnects_on_rate_limits_only",
+        "test_stream_reports_request_errors_through_tweepy",
+        "self.assertEqual([500, 429], stream.request_errors)",
         "test_stream_plan_matches_live_rule_and_filter_options",
         "test_dry_run_returns_default_plan_without_credentials_or_clients",
         "test_main_dry_run_emits_stable_json_for_repeated_track_terms",
@@ -799,6 +804,32 @@ def main():
     ):
         failures.append(
             "idempotent tweet persistence plan must record completed verification"
+        )
+
+    request_error_plan = read(REQUEST_ERROR_REPORTING_PLAN)
+    request_error_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", request_error_plan
+    )
+    request_error_verification = markdown_section(
+        request_error_plan, "Verification Completed"
+    )
+    for evidence in [
+        "25 no-network tests",
+        "make check",
+        "external working directory",
+        "hostile rollback mutation",
+        "git diff --check",
+    ]:
+        if evidence not in request_error_verification:
+            failures.append(
+                f"request error reporting verification must record {evidence}"
+            )
+    if request_error_status != ["completed"] or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run|to complete)\b",
+        request_error_verification,
+    ):
+        failures.append(
+            "request error reporting plan must record completed verification"
         )
 
     try:

--- a/test_sample_stream.py
+++ b/test_sample_stream.py
@@ -29,6 +29,7 @@ class FakeStreamingClient:
         self.added_rules = []
         self.filter_options = None
         self.disconnected = False
+        self.request_errors = []
         self.rules = list(self.initial_rules)
         self.rule_operations = []
         self.instances.append(self)
@@ -60,6 +61,9 @@ class FakeStreamingClient:
 
     def disconnect(self):
         self.disconnected = True
+
+    def on_request_error(self, status_code):
+        self.request_errors.append(status_code)
 
 
 class FakeTweets:
@@ -414,6 +418,17 @@ class SampleStreamTest(unittest.TestCase):
         stream.disconnected = False
         stream.on_request_error(420)
         self.assertTrue(stream.disconnected)
+
+    def test_stream_reports_request_errors_through_tweepy(self):
+        sample_stream = load_sample_stream()
+        stream = sample_stream.OscarsStream(
+            "bearer", mongo_client=FakeMongoClient("mongodb://example.invalid/db")
+        )
+
+        stream.on_request_error(500)
+        stream.on_request_error(429)
+
+        self.assertEqual([500, 429], stream.request_errors)
 
     def test_stream_ignores_malformed_or_incomplete_v2_payloads(self):
         sample_stream = load_sample_stream()


### PR DESCRIPTION
## Summary
- delegate every HTTP request error to Tweepy before applying local disconnect policy
- add no-network regression coverage for retryable and rate-limit statuses
- lock the behavior into static contracts and operator documentation

## Validation
- 25 no-network tests
- `make check` from repository root
- absolute Makefile gate from an external working directory
- hostile rollback mutation rejected
- hash-locked production install and dependency audit: no known vulnerabilities
- `git diff --check` and artifact/conflict/secret-shaped audits