### PR TITLE
test: make the wrong-user fixture actually exercise the author-id match

### DIFF
--- a/test_sample_stream.py
+++ b/test_sample_stream.py
@@ -447,7 +447,13 @@ class SampleStreamTest(unittest.TestCase):
             stream_payload(text="   "),
             '{"data":{"text":"missing author"},"includes":{"users":[]}}',
             '{"data":{"text":"missing user","author_id":"42"},"includes":{"users":[]}}',
-            '{"data":{"text":"wrong user","author_id":"42"},"includes":{"users":[{"id":"7","username":"academy"}]}}',
+            # This payload must carry an id. Without one, on_data bails at the
+            # tweet_id guard before the author-id match is ever consulted, so the
+            # case cannot discriminate: dropping `or user.get("id") != author_id`
+            # left the whole suite green while the mutant attributed author 42's
+            # tweet to user 7's username.
+            '{"data":{"id":"900","text":"wrong user","author_id":"42"},'
+            '"includes":{"users":[{"id":"7","username":"academy"}]}}',
         ]
 
         for payload in invalid_payloads:


### PR DESCRIPTION
## Problem

The author-id match in `expanded_username` has **zero discriminating coverage**. Deleting it entirely passes the full gate:

```diff
-        if not isinstance(user, dict) or user.get("id") != author_id:
+        if not isinstance(user, dict):
```

```
make check exit=0
Ran 25 tests in 0.032s
OK
oscars-sample-stream baseline checks passed.
```

**The cause is the fixture, not the assertion count.** The only mismatch payload (`test_sample_stream.py:450`) omits `data.id`:

```
'{"data":{"text":"wrong user","author_id":"42"},"includes":{"users":[{"id":"7","username":"academy"}]}}'
```

So `on_data` bails at the `tweet_id` guard **before the author-id match is ever consulted**. The case looks like it covers wrong-user attribution and cannot.

The `stream_payload` helper can't catch this either — it uses the same `author_id` for both `data.author_id` and `includes.users[0].id`, so the two always agree.

## Fix

Add the missing `id`. That's the whole change.

## Verification

| Tree | Result |
|---|---|
| clean | `make check` exit **0**, 25 tests OK |
| author-id match deleted | `make check` exit **2** — caught |

And the failure now names the real consequence:

```
AssertionError: Lists differ: [] != [{'_id': '900', 'text': 'wrong user', ... 'screen_name': 'academy'}]
```

That's author **42**'s tweet stored under user **7**'s username — silent misattribution.

## Severity: the shipped code is correct

This closes a coverage hole; it does not fix a live bug. The committed logic always matched author ids properly. But a refactor could have removed that match with every check in the repo still green.

## Note on provenance

I want to be transparent about how this finding reached me: it came from an audit whose earlier report was **partly fabricated** — invented findings, an invented mutation study, invented dependency-audit results. That report was retracted, and two of its five invented findings turned out to be **false and pointing at healthy code**.

So I re-derived this one from scratch before writing a line of it: located the match, read the fixture, ran the mutation against the full gate myself (`exit=0`), added the `id` and confirmed the mutant is then caught with the misattribution visible in the diff. Every number above is from my own run.

Mentioning it because "a report said so" is exactly the kind of evidence this PR argues against.

## Cleared while here — please don't "fix" these

- **`oscars` is immune to a defect its siblings have**, for a concrete reason worth preserving: its tests **hardcode** `range(101)` and `"x" * 513` rather than deriving them from the constants, so digit-extension widening (`MAX_TRACK_TERMS 100→1000`, `MAX_RULE_LENGTH 512→5120`) **is** caught here. That's the healthy anti-drift pattern, and I cited this repo as the model when fixing the equivalent hole in `gnip-light-demo` (#19 there).
- `mongo_url()`'s `MONGO_URL` fallback and `on_request_error`'s 429 handling are both genuinely tested.
- The `actions/checkout` pin is **correct** — `refs/tags/v6.0.3` is an annotated tag whose object is `9f69817` but which dereferences to the pinned commit `df4cb1c`. A filtered `git ls-remote` made this look like drift; it isn't.

## Noted, not fixed

- **Byte-vs-char rule length is non-discriminating.** `len(value.encode("utf-8"))` → `len(value)` survives, because the only fixture is pure-ASCII `"x" * 513`. Measured: a 300-char term yields a 602-byte rule that the mutant accepts. Bounded — an over-long rule is rejected by the Twitter API (the stream fails to start), not a security issue.
- **`wait_on_rate_limit=False` / `max_retries=3` are pinned by nothing** (both mutate freely). I **cannot verify the consequence**: tweepy isn't installed here and the suite runs entirely against a `FakeStreamingClient` stub that swallows both kwargs into `self.options` unasserted. I won't guess what real tweepy does with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
