### PR TITLE
Observe the gates executing and gating

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,6 +27,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install --disable-pip-version-check --require-hashes -r requirements.lock
       - run: make check
+      # `make check` is not a sufficient observer on its own: a recipe neutered
+      # with `|| true` holds it at exit 0 while the checkers still print their
+      # failures. These steps run the same gates directly, so each verdict
+      # reaches CI on a channel make cannot swallow. They are separate steps so
+      # every exit status is observed independently of shell `set -e` behavior.
+      - run: python -m unittest discover -v -s .
+      - run: python scripts/check-baseline.py
+      - run: python scripts/test-makefile-root.py
   dependency-audit:
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,49 @@
 # Changes
 
+## 2026-07-17 11:20:00 PDT - P1 - Observe the gates executing and gating
+
+### Summary
+
+Closed a verification gap in which the gates asserted that source text exists
+but nothing observed them gating. Appending ` || true` to a Makefile gate recipe
+kept every substring pin byte-identically green while holding `make check` at
+exit 0, and `make check` was CI's only observer -- so a 10x-widened validation
+bound shipped green.
+
+### Work completed
+
+- Replaced the Makefile recipe substring pins with an anchored, recipe-scoped
+  whole-line pin rejecting appended shell, ignored/silenced prefixes, extra
+  commands, deletion, and relocation.
+- Added out-of-band CI steps running the tests and both checkers directly, as
+  separate steps, so a checker's verdict reaches CI on a channel make cannot
+  swallow; pinned those steps whole-line so the layers cover each other.
+- Pinned the bound tests' literal fixtures and message assertions, matching the
+  assertion-body pinning already applied to other tests.
+- Added planted-defect controls that apply each mutation to real Makefile text,
+  execute the pin, and assert the failure message.
+
+### Threads
+
+- None; the focused gate-observation work was completed directly.
+
+### Files changed
+
+- `scripts/check-baseline.py` — whole-line recipe pins, out-of-band CI step
+  pins, and bound-test assertion pins.
+- `scripts/test-makefile-root.py` — planted-defect controls for the recipe pin.
+- `.github/workflows/check.yml` — observe the gates directly, out of band from
+  make, via external absolute-Makefile calls to the reviewed commands.
+- `docs/plans/2026-07-17-out-of-band-gate-observation.md` — record the probes,
+  both directions, and the residual limit.
+
+### Validation
+
+- `make check` green on a clean tree before and after (25 stream tests, 10 make
+  root tests).
+- Mutation evidence recorded in both directions in the plan; each mutation
+  confirmed to apply and to import/run before its result was recorded.
+
 ## 2026-06-26 13:43:18 PDT - P1 - Preserve stream HTTP error reporting
 
 ### Summary

--- a/docs/plans/2026-07-17-out-of-band-gate-observation.md
+++ b/docs/plans/2026-07-17-out-of-band-gate-observation.md
@@ -1,0 +1,80 @@
+# Out-of-band gate observation
+
+status: completed
+
+## Problem
+
+The repository's gates asserted that source text exists but nothing observed
+them *gating*. Two independent, small edits shipped a 10x-widened validation
+bound with every gate green:
+
+1. `scripts/check-baseline.py` pinned each Makefile gate recipe with a
+   substring test (`if phrase not in makefile`). The reviewed command is a
+   *prefix* of the same command with ` || true` appended, so appending
+   ` || true` to a recipe kept the pin byte-identically green while destroying
+   the exit status the gate's verdict travels on. `make check` was CI's only
+   observer, so CI stayed green while `check-baseline.py` printed its failures.
+2. `MAX_TRACK_TERMS = 100` and `MAX_RULE_LENGTH = 512` were pinned as
+   substrings, so `MAX_TRACK_TERMS = 1000` kept the pin green (prefix match).
+   The literal-fixture tests were the only real detector, and only their test
+   *names* were pinned -- not their bodies -- so gutting a body to `pass` while
+   widening the constant was invisible to every layer.
+
+## Work Completed
+
+- Replaced the three Makefile recipe substring pins with an anchored,
+  recipe-scoped whole-line pin (`makefile_recipe_failures`) that compares each
+  target's recipe line list for equality. This rejects ` || true`, `; true`,
+  `|| exit 0`, a leading `-` or `@echo`, extra commands, recipe deletion, and
+  relocation to an unused target.
+- Upgraded the Makefile dependency graph lines to whole-line pins.
+- Added out-of-band CI steps that run `unittest`, `check-baseline.py`, and
+  `test-makefile-root.py` **directly**, as separate steps. An in-Makefile pin
+  cannot catch ` || true` on its own recipe -- the checker detects it, prints
+  it, and `make check` still exits 0 -- so a checker running outside make is the
+  only channel its verdict can reach CI on. Those steps are themselves
+  whole-line pinned, so the two layers cover each other rather than themselves.
+- Pinned the two bound tests' literal fixtures and message assertions
+  (`range(101)`, `"x" * 513`, `assertRaisesRegex` messages), matching the
+  assertion-body pinning the checker already applied to other tests.
+- Added planted-defect controls in `scripts/test-makefile-root.py` that apply
+  each mutation to real Makefile text and execute the pin, asserting the
+  failure *message* so a mutation that fails for an unrelated reason cannot be
+  misread as detection. Each control asserts its own mutation applied.
+
+## Verification Completed
+
+Baseline was green before probing. Every probe below was applied by hand and
+confirmed to import and run; hit counts and `git diff --stat` proved each
+mutation landed.
+
+Before the fix:
+
+- `MAX_TRACK_TERMS = 100` -> `1000`: pin green, `make static-check` exit 0.
+  Caught only by the literal-fixture test.
+- `MAX_RULE_LENGTH = 512` -> `5120`: pin green, `make static-check` exit 0.
+  Caught only by the literal-fixture test.
+- ` || true` on the test recipe + widened bound: pin green, tests printed
+  `FAILED (failures=1)`, `make check` exit **0**.
+- ` || true` on all three recipes + widened bound + broken `RULE_TAG`:
+  11 test failures, `check-baseline.py` printed its own violation,
+  `make check` exit **0**.
+- Test body gutted to `pass` + widened bound: `make check` exit **0**.
+
+After the fix:
+
+- Makefile-only neuter: direct CI steps exit 1 with attribution naming the
+  exact neutered recipe.
+- Workflow direct-step neuter, and deletion of all three direct steps:
+  `make check` exit 2.
+- Body gutted + widened bound: `make check` exit 2, direct checker exit 1.
+- Composite (gutted body + widened bound + ` || true` on all recipes):
+  direct `check-baseline.py` exit 1 with correct attribution.
+
+## Residual Limit
+
+Neutering the Makefile **and** editing the workflow's direct steps in the same
+change still exits 0. A static gate cannot defend against its own deletion;
+that floor is held by CODEOWNERS review and required status checks, not by this
+checker. The fix moves the attack from an invisible one-token Makefile append to
+conspicuous surgery on a CODEOWNERS-gated workflow file.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -24,6 +24,34 @@ IDEMPOTENT_RULE_SYNC_PLAN = "docs/plans/2026-06-16-idempotent-stream-rule-sync.m
 MATCHING_RULE_CLEANUP_PLAN = "docs/plans/2026-06-17-matching-stream-rule-cleanup.md"
 IDEMPOTENT_TWEET_PERSISTENCE_PLAN = "docs/plans/2026-06-17-idempotent-tweet-persistence.md"
 REQUEST_ERROR_REPORTING_PLAN = "docs/plans/2026-06-26-request-error-reporting.md"
+OUT_OF_BAND_GATE_PLAN = "docs/plans/2026-07-17-out-of-band-gate-observation.md"
+EXPECTED_MAKEFILE_RECIPES = {
+    "test": [
+        "PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m unittest discover -v -s $(SHELL_REPO_ROOT)"
+    ],
+    "static-check": [
+        "PYTHONDONTWRITEBYTECODE=1 $(PYTHON) $(SHELL_REPO_ROOT)/scripts/check-baseline.py"
+    ],
+    "root-test": [
+        "PYTHONDONTWRITEBYTECODE=1 $(PYTHON) $(SHELL_REPO_ROOT)/scripts/test-makefile-root.py"
+    ],
+}
+EXPECTED_MAKEFILE_GRAPH = [
+    "PYTHON ?= python3",
+    "check: test lint root-test",
+    "verify: check",
+    "build: static-check",
+    "lint: static-check",
+]
+# Steps that must observe the gates directly, out of band from make. A recipe
+# neutered with `|| true` still exits 0 through `make check`, so these steps are
+# the only channel a checker's verdict can reach CI on.
+EXPECTED_DIRECT_CI_STEPS = [
+    "- run: make check",
+    "- run: python -m unittest discover -v -s .",
+    "- run: python scripts/check-baseline.py",
+    "- run: python scripts/test-makefile-root.py",
+]
 PRODUCTION_LOCK_SHA256 = "27ea76d7d0f7efea504ebcee475e411502bc775dceab3e10501563085d77ce1c"
 AUDIT_LOCK_SHA256 = "fc7ce7c6f13eee2008ea150facb1560903d6d12f4d6ad5245e68fdc3a75e607b"
 REQUIRED = [
@@ -63,6 +91,7 @@ REQUIRED = [
     MATCHING_RULE_CLEANUP_PLAN,
     IDEMPOTENT_TWEET_PERSISTENCE_PLAN,
     REQUEST_ERROR_REPORTING_PLAN,
+    OUT_OF_BAND_GATE_PLAN,
     "requirements-audit.in",
     "requirements-audit.lock",
     "requirements.txt",
@@ -98,6 +127,40 @@ def hashed_lock_inventory(text):
             return {}
         entries[name] = (match.group(2), hashes)
     return entries
+
+
+def makefile_recipes(text):
+    """Map each Makefile target to its exact recipe lines, tab prefix removed."""
+    recipes = {}
+    current = None
+    for line in text.splitlines():
+        if line.startswith("\t"):
+            if current is not None:
+                recipes.setdefault(current, []).append(line[1:])
+            continue
+        match = re.match(r"^([A-Za-z0-9_./-]+)[ \t]*:(?!=)", line)
+        current = match.group(1) if match else None
+    return recipes
+
+
+def makefile_recipe_failures(text):
+    """Require each gate recipe to be exactly the reviewed command.
+
+    A substring pin cannot see text appended to a recipe, so `|| true`, a
+    leading `-` or `@echo`, an extra command, or a relocated recipe all keep a
+    substring pin green while destroying the exit status the gate's verdict
+    travels on. Comparing the recipe line list for equality closes that gap.
+    """
+    failures = []
+    recipes = makefile_recipes(text)
+    for target, expected in sorted(EXPECTED_MAKEFILE_RECIPES.items()):
+        found = recipes.get(target)
+        if found != expected:
+            failures.append(
+                "Makefile target {} must run exactly {} with no appended shell, "
+                "prefix, or extra command (found {})".format(target, expected, found)
+            )
+    return failures
 
 
 def main():
@@ -248,6 +311,17 @@ def main():
         "self.assertEqual([\"second\"], stream.deleted_rule_ids)",
         "self.assertEqual([\"stale\"], stream.deleted_rule_ids)",
         "self.assertIsNone(stream.filter_options)",
+        # The bound constants are pinned only as a prefix in sample_stream.py, so
+        # widening one by appending a digit keeps that pin green. These literal
+        # fixtures and message assertions are the only layer that detects such a
+        # widening, so pin the assertion bodies -- not just the test names -- to
+        # keep the boundary literal rather than expressed in terms of the
+        # constant it is meant to police.
+        'track_terms = ("term-{}".format(index) for index in range(101))',
+        'with self.assertRaisesRegex(ValueError, "more than 100"):',
+        "sample_stream.start_stream(track_terms)",
+        'with self.assertRaisesRegex(ValueError, "larger than 512 bytes"):',
+        'sample_stream.start_stream(["x" * 513])',
         "test_rule_terms_are_literal_and_bounded",
         "test_start_stream_accepts_single_custom_track_term",
         "test_start_stream_rejects_invalid_track_terms_before_client_setup",
@@ -302,16 +376,14 @@ def main():
         "override REPO_ROOT := $(shell path=",
         "override SHELL_REPO_ROOT :=",
         'CDPATH= cd -- "$$directory" && /bin/pwd -P)',
-        "PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m unittest discover -v -s $(SHELL_REPO_ROOT)",
-        "PYTHONDONTWRITEBYTECODE=1 $(PYTHON) $(SHELL_REPO_ROOT)/scripts/check-baseline.py",
-        "PYTHONDONTWRITEBYTECODE=1 $(PYTHON) $(SHELL_REPO_ROOT)/scripts/test-makefile-root.py",
-        "check: test lint root-test",
-        "lint: static-check",
-        "build: static-check",
-        "verify: check",
     ]:
         if phrase not in makefile:
             failures.append(f"Makefile must include {phrase}")
+    failures.extend(makefile_recipe_failures(makefile))
+    makefile_lines = makefile.splitlines()
+    for expected_line in EXPECTED_MAKEFILE_GRAPH:
+        if expected_line not in makefile_lines:
+            failures.append(f"Makefile must keep the exact line {expected_line}")
 
     root_test = read("scripts/test-makefile-root.py")
     for phrase in [
@@ -322,6 +394,12 @@ def main():
         '" ; touch QUOTE_PWNED ; echo "',
         "self.assertFalse((checkout.parent / marker_name).exists(), result.stdout)",
         'self.assertIn("live root stub passed", result.stdout)',
+        "def test_live_makefile_recipes_satisfy_the_pin",
+        "def test_pin_rejects_exit_status_neutering_on_every_gate_recipe",
+        "def test_pin_rejects_silenced_and_ignored_recipe_prefixes",
+        "def test_pin_rejects_deleted_and_relocated_gate_recipe",
+        "def test_workflow_keeps_direct_out_of_band_gate_steps",
+        "baseline.makefile_recipe_failures(mutated)",
     ]:
         if phrase not in root_test:
             failures.append(f"Make root regression must include {phrase}")
@@ -342,7 +420,6 @@ def main():
         "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
         'python-version: ["3.10", "3.12"]',
         "PYTHONDONTWRITEBYTECODE: \"1\"",
-        "run: make check",
         "dependency-audit:",
         "python -m pip install --disable-pip-version-check --require-hashes -r requirements.lock",
         "python -m pip install --disable-pip-version-check --require-hashes -r requirements-audit.lock",
@@ -350,6 +427,13 @@ def main():
     ]:
         if expected not in workflow:
             failures.append(f"Check workflow must keep {expected}")
+    workflow_lines = [line.strip() for line in workflow.splitlines()]
+    for expected_step in EXPECTED_DIRECT_CI_STEPS:
+        if expected_step not in workflow_lines:
+            failures.append(
+                f"Check workflow must run {expected_step} as its own step so a "
+                "neutered Makefile recipe cannot swallow the verdict"
+            )
     if workflow.count("persist-credentials: false") != 2:
         failures.append("Check workflow must disable persisted credentials for both jobs")
     if len(workflow_files) != 1:

--- a/scripts/test-makefile-root.py
+++ b/scripts/test-makefile-root.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import importlib.util
 import os
 from pathlib import Path
 import shlex
@@ -8,6 +9,18 @@ import unittest
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_baseline_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_baseline", ROOT / "scripts" / "check-baseline.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+baseline = load_baseline_module()
 
 
 class MakefileRootTests(unittest.TestCase):
@@ -88,6 +101,77 @@ class MakefileRootTests(unittest.TestCase):
         ):
             with self.subTest(checkout_name=checkout_name):
                 self.assert_live_root_path_is_literal(checkout_name, marker_name)
+
+
+class MakefileRecipePinTests(unittest.TestCase):
+    """Planted-defect controls for the exact-recipe pin.
+
+    Each mutation is applied to real Makefile text and the pin is executed, so a
+    green result here means the pin ran and produced a verdict rather than that
+    a harness merely reported one.
+    """
+
+    def setUp(self):
+        self.makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+
+    def test_live_makefile_recipes_satisfy_the_pin(self):
+        self.assertEqual([], baseline.makefile_recipe_failures(self.makefile))
+
+    def test_pin_parses_every_expected_gate_recipe(self):
+        recipes = baseline.makefile_recipes(self.makefile)
+        for target, expected in baseline.EXPECTED_MAKEFILE_RECIPES.items():
+            self.assertEqual(expected, recipes.get(target), target)
+
+    def test_pin_rejects_exit_status_neutering_on_every_gate_recipe(self):
+        for target, expected in baseline.EXPECTED_MAKEFILE_RECIPES.items():
+            for suffix in (" || true", " ; true", " || exit 0"):
+                with self.subTest(target=target, suffix=suffix):
+                    mutated = self.makefile.replace(
+                        "\t" + expected[0] + "\n",
+                        "\t" + expected[0] + suffix + "\n",
+                        1,
+                    )
+                    self.assertNotEqual(self.makefile, mutated, "mutation must apply")
+                    failures = baseline.makefile_recipe_failures(mutated)
+                    self.assertTrue(failures, f"{target}{suffix} must be rejected")
+                    self.assertIn(f"Makefile target {target} must run exactly", failures[0])
+
+    def test_pin_rejects_silenced_and_ignored_recipe_prefixes(self):
+        expected = baseline.EXPECTED_MAKEFILE_RECIPES["test"][0]
+        for prefix in ("@echo ", "-"):
+            with self.subTest(prefix=prefix):
+                mutated = self.makefile.replace(
+                    "\t" + expected + "\n", "\t" + prefix + expected + "\n", 1
+                )
+                self.assertNotEqual(self.makefile, mutated, "mutation must apply")
+                self.assertIn(
+                    "Makefile target test must run exactly",
+                    " ".join(baseline.makefile_recipe_failures(mutated)),
+                )
+
+    def test_pin_rejects_deleted_and_relocated_gate_recipe(self):
+        expected = baseline.EXPECTED_MAKEFILE_RECIPES["static-check"][0]
+        deleted = self.makefile.replace("\t" + expected + "\n", "", 1)
+        self.assertNotEqual(self.makefile, deleted, "mutation must apply")
+        self.assertIn(
+            "Makefile target static-check must run exactly",
+            " ".join(baseline.makefile_recipe_failures(deleted)),
+        )
+        relocated = deleted + "unused-target:\n\t" + expected + "\n"
+        self.assertIn(
+            "Makefile target static-check must run exactly",
+            " ".join(baseline.makefile_recipe_failures(relocated)),
+        )
+
+    def test_workflow_keeps_direct_out_of_band_gate_steps(self):
+        workflow_lines = [
+            line.strip()
+            for line in (ROOT / ".github/workflows/check.yml")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        ]
+        for step in baseline.EXPECTED_DIRECT_CI_STEPS:
+            self.assertIn(step, workflow_lines)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The question

Does this repo's gate observe its runners **executing and gating**, or does it
only assert that source text exists?

It only asserted text. Baseline was green before probing (25 tests, exit 0), so
every probe below is meaningful. Each mutation was applied by hand, confirmed to
import and run, and proven to land with a hit count and `git diff --stat`.

## The gap

`scripts/check-baseline.py` pinned each Makefile gate recipe with a substring
test:

```python
if phrase not in makefile:
    failures.append(f"Makefile must include {phrase}")
```

The reviewed command is a **prefix** of the same command with ` || true`
appended, so appending ` || true` keeps the pin byte-identically green while
destroying the exit status the gate's verdict travels on. `run: make check` was
CI's **only** observer, and `check-baseline.py` was invoked *only* from the
Makefile -- so there was no channel by which any checker's verdict could reach
CI once a recipe was neutered.

Two separate layers were affected:

1. **Exit-status channel.** ` || true` on a recipe holds `make check` at exit 0.
2. **Constant pins.** `MAX_TRACK_TERMS = 100` and `MAX_RULE_LENGTH = 512` are
   pinned as substrings, so `MAX_TRACK_TERMS = 1000` keeps the pin green (prefix
   match). The literal-fixture tests were the only real detector -- and only
   their test *names* were pinned, not their bodies.

## Mutation evidence, both directions

| Probe (applied by hand, confirmed to run) | `make check` before fix | After fix |
|---|---|---|
| `MAX_TRACK_TERMS = 100` -> `1000` (append) | pin green; `static-check` exit **0**; caught only by literal-fixture test (exit 2) | exit 2 |
| `MAX_RULE_LENGTH = 512` -> `5120` (append) | pin green; `static-check` exit **0**; caught only by literal-fixture test (exit 2) | exit 2 |
| ` || true` on test recipe + widened bound | all pins green; `FAILED (failures=1)` printed; exit **0** | direct CI steps exit **1**, attribution names the exact recipe |
| ` || true` on all 3 recipes + widened bound + broken `RULE_TAG` | 11 test failures; `check-baseline.py` printed its own violation; exit **0** | direct checkers exit **1** |
| Test body gutted to `pass` + widened bound | exit **0** (name pin still satisfied) | exit 2; direct checker exit 1 |
| Composite: gutted body + widened bound + ` || true` on all recipes | exit **0** | direct `check-baseline.py` exit **1**, correct attribution |
| Workflow direct-step neutered with ` || true` | n/a | `make check` exit **2** |
| All 3 direct CI steps deleted | n/a | `make check` exit **2** |

The clearest single result: with ` || true` on all three recipes,
`check-baseline.py` **detected** the violation, **printed**
`sample_stream.py must include RULE_TAG = "oscars-sample-stream"`, 11 tests
failed -- and `make check` exited **0**.

## The fix

- **Anchored, recipe-scoped whole-line pin** (`makefile_recipe_failures`)
  comparing each target's recipe line list for equality. Rejects ` || true`,
  `; true`, `|| exit 0`, a leading `-` or `@echo`, extra commands, recipe
  deletion, and relocation to an unused target.
- **Out-of-band CI observers.** An in-Makefile pin is worthless alone against
  ` || true` on its own recipe: the checker detects it, prints it, and
  `make check` still exits 0. So `check.yml` now runs the tests and both
  checkers **directly**, as separate steps (separate so each exit status is
  observed independently of shell `set -e` behavior). Those steps are themselves
  whole-line pinned -- the two layers cover **each other**, not themselves.
- **Bound-test assertion pins.** The checker already pinned assertion bodies for
  other tests (`rule_operations`, `deleted_rule_ids`, `request_errors`,
  `on_error(420)`); coverage had run out exactly one line short, on the two
  tests the constant pins depend on. Now pins `range(101)`, `"x" * 513`, and the
  `assertRaisesRegex` messages, keeping the boundary **literal** rather than
  expressed in terms of the constant it polices.
- **Planted-defect controls that actually run** (`MakefileRecipePinTests`): each
  applies its mutation to real Makefile text, asserts the mutation applied, then
  executes the pin and asserts the failure **message** -- so a mutation failing
  for an unrelated reason cannot be misread as detection.

## What I cleared

- Makefile recipes contain no `|| true`, `-` prefix, or `@echo` today; no
  swallowed-failure `for`/`if` shell lists; no `sh -c` without `set -e`.
- `MAX_TRACK_TERMS`/`MAX_RULE_LENGTH` fixtures are **literal** (`range(101)`,
  `"x" * 513`), not self-referential -- a widened bound *is* caught by the tests.
  This is the one place the account-wide "fixtures move with the constant" trap
  does **not** apply here.
- `assertRaisesRegex` asserts the **message**, not just the type. This is
  load-bearing: with `MAX_TRACK_TERMS = 1000`, the 101-term fixture falls through
  to the *rule-length* guard, which raises the same `ValueError`. A bare
  `assertRaises(ValueError)` would have passed silently. The message assert is
  what makes the fall-through visible.
- No tree-clean assert, so probes were not "caught" for the wrong reason. The
  `git diff --check` hits in `check-baseline.py` are pinned doc evidence strings,
  not executed commands.
- Every pinned string traces to a real entry point: `check-baseline.py` and
  `test-makefile-root.py` are both genuinely invoked by `make check`.
- No mutation harness in-repo, so no canary risk.

## Residual limit, stated honestly

Neutering the Makefile **and** editing the workflow's direct steps in one change
still exits 0. A static gate cannot defend against its own deletion; that floor
is held by CODEOWNERS review and required status checks. The fix moves the attack
from an invisible one-token Makefile append to conspicuous surgery on a
CODEOWNERS-gated workflow file.

## Verification

`make check` green on a clean tree before and after (25 stream tests, 10 make
root tests -- up from 4). All three out-of-band steps exit 0 on a clean tree.
`git diff --check` clean; no bytecode left behind; workflow parses as YAML.

No source behavior changed: `sample_stream.py` and `test_sample_stream.py` are
untouched. This is purely gate hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
